### PR TITLE
add EPS payment method

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -100,6 +100,10 @@
                 <label for="payment-bancontact">Bancontact</label>
               </li>
               <li>
+                <input type="radio" name="payment" id="payment-eps" value="eps">
+                <label for="payment-eps">EPS</label>
+              </li>
+              <li>
                 <input type="radio" name="payment" id="payment-ideal" value="ideal">
                 <label for="payment-ideal">iDEAL</label>
               </li>

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -419,6 +419,11 @@
       name: 'Card',
       flow: 'none',
     },
+    eps: {
+      name: 'EPS',
+      flow: 'redirect',
+      countries: ['AT'],
+    },
     ideal: {
       name: 'iDEAL',
       flow: 'redirect',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
- add redirect flow based payment method EPS: https://stripe.com/docs/sources/eps
- this is pretty much equivalent to Giropay, but only supports banks in Austria