### PR TITLE
Add WeChat Pay and Alipay as available payment methods in Japan

### DIFF
--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -453,7 +453,7 @@
     alipay: {
       name: 'Alipay',
       flow: 'redirect',
-      countries: ['CN', 'HK', 'SG'],
+      countries: ['CN', 'HK', 'SG', 'JP'],
     },
     bancontact: {
       name: 'Bancontact',
@@ -497,7 +497,7 @@
     wechat: {
       name: 'WeChat',
       flow: 'none',
-      countries: ['CN', 'HK', 'SG'],
+      countries: ['CN', 'HK', 'SG', 'JP'],
     },
   };
 


### PR DESCRIPTION
Changes proposed in this pull request:
- WeChat Pay as a payment method in Japan
- Alipay as a payment method in Japan