### PR TITLE
add single_use ACH credit transfer payment method

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -92,6 +92,10 @@
                 <label for="payment-card">Card</label>
               </li>
               <li>
+                <input type="radio" name="payment" id="payment-ach_credit_transfer" value="ach_credit_transfer" checked>
+                <label for="payment-ach_credit_transfer">Bank Transfer</label>
+              </li>
+              <li>
                 <input type="radio" name="payment" id="payment-alipay" value="alipay">
                 <label for="payment-alipay">Alipay</label>
               </li>
@@ -182,6 +186,7 @@
       <div class="status error">
         <h1>Oops, payment failed.</h1>
         <p>It looks like your order could not be paid at this time. Please try again or select a different payment option.</p>
+        <p class="error-message"></p>
       </div>
     </div>
   </div>

--- a/public/stylesheets/store.css
+++ b/public/stylesheets/store.css
@@ -752,6 +752,10 @@ button:active {
   display: flex;
 }
 
+#main.error #confirmation .error-message {
+  font-family: monospace;
+}
+
 /* Media Queries */
 
 @media only screen and (max-width: 1024px) {


### PR DESCRIPTION
- adds ACH Credit Transfer payment method in single-use mode: https://stripe.com/docs/sources/ach-credit-transfer
- adds support for showing source creation error message