### PR TITLE
Use shipping recipient's name in shipping address

### DIFF
--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -117,7 +117,7 @@
         store.getOrderItems(),
         event.payerEmail,
         {
-          name: event.payerName,
+          name: event.shippingAddress.recipient,
           address: {
             line1: event.shippingAddress.addressLine[0],
             city: event.shippingAddress.city,
@@ -180,7 +180,9 @@
       form.querySelector('label.zip span').innerText =
         country === 'US'
           ? 'ZIP'
-          : country === 'UK' ? 'Postcode' : 'Postal Code';
+          : country === 'UK'
+            ? 'Postcode'
+            : 'Postal Code';
       event.target.parentElement.className = `field ${country}`;
       showRelevantPaymentMethods(country);
     });


### PR DESCRIPTION
r? @romain-stripe 

In our Payment Request integration, we use `event.payerName` for the shipping recipient's name, even though we don't ask for `requestPayerName: true`. This results in `name` always being `null`.

Since the address is used for shipping, we should use `event.shippingAddress.recipient` instead.