### PR TITLE
Filter products by type

### DIFF
--- a/server/node/inventory.js
+++ b/server/node/inventory.js
@@ -38,7 +38,7 @@ const updateOrder = async (orderId, properties) => {
 
 // List all products.
 const listProducts = async () => {
-  return await stripe.products.list({limit: 3});
+  return await stripe.products.list({limit: 3, type: 'good'});
 };
 
 // Retrieve a product by ID.


### PR DESCRIPTION
Filter products by `type:good` to prevent interference with Stripe Billing products of type service introduced in API version 2018-02-05[0]

[0] https://stripe.com/docs/upgrades#2018-02-05