### PR TITLE
server/python: update flask to 0.12.4

### DIFF
--- a/server/python/requirements.txt
+++ b/server/python/requirements.txt
@@ -3,7 +3,7 @@ attrs==17.4.0
 certifi==2018.1.18
 chardet==3.0.4
 click==6.7
-Flask==0.12.2
+Flask==0.12.4
 gunicorn==19.7.1
 idna==2.6
 idna-ssl==1.0.1


### PR DESCRIPTION
r? @adreyfus-stripe 

There's a security vulnerability in Flask 0.12.2 (https://nvd.nist.gov/vuln/detail/CVE-2018-1000656) that could allow a denial of service.  I *think* that this application is most likely not affected, as we don't invoke Flask's `json()` or `get_json()` directly, but it's probably best to update just in case there's a non-obvious code path that hits it.