### PR TITLE
Change to PaymentIntents for all payment methods and upgrade to API version 2019-02-11

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ STRIPE_WEBHOOK_SECRET=
 # Stripe account country (required for Payment Request).
 STRIPE_ACCOUNT_COUNTRY=US
 
+# Supported payment methods for the store.
+# Some payment methods support only a subset of currencies.
+# Make sure to check the docs: https://stripe.com/docs/sources
+# Only used for the python server. For Node.js see the server/node/config.js file!
+PAYMENT_METHODS="alipay, bancontact, card, eps, ideal, giropay, multibanco, sofort, wechat"
+
 # Optional ngrok configuration for development (if you have a paid ngrok account).
 NGROK_SUBDOMAIN=
 NGROK_AUTHTOKEN=

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This demo provides an all-in-one example for integrating with Stripe on the web:
 🚀 | **Built-in proxy for local HTTPS and webhooks.** Card payments require HTTPS and asynchronous payment methods with redirects rely on webhooks to complete transactions—[ngrok](https://ngrok.com/) is integrated so the app is served locally over HTTPS and an endpoint is publicly exposed for webhooks.
 🔧 | **Webhook signing and idempotency keys**. We verify webhook signatures and pass idempotency keys to charge creations, two recommended practices for asynchronous payment flows.
 📱 | **Responsive design**. The checkout experience works on all screen sizes. Apple Pay works on Safari for iPhone and iPad if the Wallet is enabled, and Payment Request works on Chrome for Android.
-📦 | **No datastore required.** Products, SKUs, and Orders are stored using the [Stripe Orders API](https://stripe.com/docs/orders), which you can replace with your own database to keep track of orders and inventory.
+📦 | **No datastore required.** Products, and SKUs are stored using the [Stripe API](https://stripe.com/docs/api/products), which you can replace with your own database to keep track of products and inventory.
 
 ## Payments Integration
 
@@ -67,9 +67,9 @@ There are a couple server implementations in the [`server`](/server) directory. 
 
 You’ll need the following:
 
-* [Node.js](http://nodejs.org) >= 8.x.
-* Modern browser that supports ES6 (Chrome to see the Payment Request, and Safari to see Apple Pay).
-* Stripe account to accept payments ([sign up](https://dashboard.stripe.com/register) for free).
+- [Node.js](http://nodejs.org) >= 8.x.
+- Modern browser that supports ES6 (Chrome to see the Payment Request, and Safari to see Apple Pay).
+- Stripe account to accept payments ([sign up](https://dashboard.stripe.com/register) for free).
 
 In your Stripe Dashboard, you can [enable the payment methods](https://dashboard.stripe.com/payments/settings) you’d like to test with one click.
 
@@ -87,7 +87,7 @@ Install dependencies using npm:
 
     npm install
 
-This demo uses the Stripe API as a datastore for products and orders, but you can always choose to use your own datastore instead. When starting the app for the first time, the initial loading can take a couple of seconds as it will automatically set up the products within Stripe.
+This demo uses the Stripe API as a datastore for products and SKUs, but you can always choose to use your own datastore instead. When starting the app for the first time, the initial loading can take a couple of seconds as it will automatically set up the products and SKUs within Stripe.
 
 Run the app:
 
@@ -111,5 +111,5 @@ Use this second URL in your browser to start the demo.
 
 ## Credits
 
-* Code: [Romain Huet](https://twitter.com/romainhuet) and [Thorsten Schaeff](https://twitter.com/thorwebdev)
-* Design: [Tatiana Van Campenhout](https://twitter.com/tatsvc)
+- Code: [Romain Huet](https://twitter.com/romainhuet) and [Thorsten Schaeff](https://twitter.com/thorwebdev)
+- Design: [Tatiana Van Campenhout](https://twitter.com/tatsvc)

--- a/public/index.html
+++ b/public/index.html
@@ -221,13 +221,20 @@
       <div class="line-item demo">
         <div id="demo">
           <p class="label">Demo in test mode</p>
-          <p class="note">This app is running in test mode. You will
-            <em>not</em> be charged.</p>
-          <p class="note"> Feel free to test payments using a real card or any
-            <a href="https://stripe.com/docs/testing#cards" target="_blank">Stripe test card</a>. Non-card payments will redirect to test pages.
-          </p>
-          <p class="note">Run this app locally in live mode with your Stripe account to create real payments and see redirects to banking
-            sites.
+          <p class="note">You can copy and paste the following test cards to trigger different scenarios:</p>
+          <table class="note">
+            <tr>
+              <td>Default US card:</td>
+              <td class="card-number">4242<span></span>4242<span></span>4242<span></span>4242</td>
+            </tr>
+            <tr>
+              <td><a href="https://stripe.com/guides/strong-customer-authentication" target="_blank">3D Secure auth</a> required:</td>
+              <td class="card-number">4000<span></span>0000<span></span>0000<span></span>3063</td>
+            </tr>
+            </table>
+          <p class="note"> 
+            See the <a href="https://stripe.com/docs/testing#cards" target="_blank">docs</a> for a full list of test cards. 
+            Non-card payments will redirect to test pages.
           </p>
         </div>
       </div>

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -155,6 +155,12 @@
         detail: 'Delivery within 5 days',
         amount: 0,
       },
+      {
+        id: 'express',
+        label: 'Express Shipping',
+        detail: 'Next day delivery',
+        amount: 500,
+      },
     ],
   });
 
@@ -177,6 +183,23 @@
   // Callback when the shipping address is updated.
   paymentRequest.on('shippingaddresschange', event => {
     event.updateWith({status: 'success'});
+  });
+
+  // Callback when the shipping option is changed.
+  paymentRequest.on('shippingoptionchange', async event => {
+    // Update the PaymentIntent to reflect the shipping cost.
+    const response = await store.updatePaymentIntentWithShippingCost(
+      paymentIntent.id,
+      store.getPaymentItems(),
+      event.shippingOption
+    );
+    event.updateWith({
+      total: {
+        label: 'Total',
+        amount: response.paymentIntent.amount,
+      },
+      status: 'success',
+    });
   });
 
   // Create the Payment Request Button.

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -148,20 +148,7 @@
     },
     requestShipping: true,
     requestPayerEmail: true,
-    shippingOptions: [
-      {
-        id: 'free',
-        label: 'Free Shipping',
-        detail: 'Delivery within 5 days',
-        amount: 0,
-      },
-      {
-        id: 'express',
-        label: 'Express Shipping',
-        detail: 'Next day delivery',
-        amount: 500,
-      },
-    ],
+    shippingOptions: config.shippingOptions,
   });
 
   // Callback when a source is created.
@@ -211,6 +198,11 @@
       },
       status: 'success',
     });
+    const amount = store.formatPrice(
+      response.paymentIntent.amount,
+      config.currency
+    );
+    submitButton.innerText = `Pay ${amount}`;
   });
 
   // Create the Payment Request Button.

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -190,7 +190,7 @@
     // Update the PaymentIntent to reflect the shipping cost.
     const response = await store.updatePaymentIntentWithShippingCost(
       paymentIntent.id,
-      store.getPaymentItems(),
+      store.getLineItems(),
       event.shippingOption
     );
     event.updateWith({
@@ -542,7 +542,7 @@
     // Create the PaymentIntent with the cart details.
     const response = await store.createPaymentIntent(
       config.currency,
-      store.getPaymentItems()
+      store.getLineItems()
     );
     paymentIntent = response.paymentIntent;
   }

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -277,11 +277,13 @@
       );
       handlePayment(response);
     } else if (payment === 'sepa_debit') {
-      const response = await stripe.handleSepaDebitPayment(
+      // Confirm the PaymentIntent with the IBAN Element and additional SEPA Debit source data.
+      const response = await stripe.confirmPaymentIntent(
         paymentIntent.client_secret,
         iban,
         {
           source_data: {
+            type: 'sepa_debit',
             owner: {
               name,
               email,

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -237,7 +237,7 @@
     };
     // Disable the Pay button to prevent multiple click events.
     submitButton.disabled = true;
-    submitButton.textContent = 'Processing Payment…';
+    submitButton.textContent = 'Processing…';
 
     if (payment === 'card') {
       // Let Stripe.js handle the confirmation of the PaymentIntent with the card Element.
@@ -505,7 +505,7 @@
     window.location.search.includes('source')
   ) {
     // Update the interface to display the processing screen.
-    mainElement.classList.add('success', 'processing');
+    mainElement.classList.add('checkout', 'success', 'processing');
 
     // Poll the PaymentIntent status.
     pollPaymentIntentStatus(paymentIntent_client_secret);
@@ -520,6 +520,7 @@
     );
     paymentIntent = response.paymentIntent;
   }
+  document.getElementById('main').classList.remove('loading');
 
   /**
    * Display the relevant payment methods for a selected country.

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -704,7 +704,8 @@
       input.parentElement.classList.toggle(
         'visible',
         input.value === 'card' ||
-          (paymentMethods[input.value].countries.includes(country) &&
+          (config.paymentMethods.includes(input.value) &&
+            paymentMethods[input.value].countries.includes(country) &&
             paymentMethods[input.value].currencies.includes(config.currency))
       );
     }

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -26,7 +26,7 @@ class Store {
   }
 
   // Expose the line items for the payment using products and skus stored in Stripe.
-  getPaymentItems() {
+  getLineItems() {
     let items = [];
     this.lineItems.forEach(item =>
       items.push({

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -75,8 +75,6 @@ class Store {
       if (data.error) {
         return {error: data.error};
       } else {
-        // Save the current PaymentIntent client secret locally to lookup its status later.
-        this.setActivePaymentIntent(data.paymentIntent.client_secret);
         return data;
       }
     } catch (err) {
@@ -93,19 +91,6 @@ class Store {
       currencyDisplay: 'symbol',
     });
     return numberFormat.format(price);
-  }
-
-  // Set the active PaymentIntent client secret in the local storage.
-  setActivePaymentIntent(paymentIntent_client_secret) {
-    localStorage.setItem(
-      'paymentIntent_client_secret',
-      paymentIntent_client_secret
-    );
-  }
-
-  // Get the active PaymentIntent client secret from the local storage.
-  getActivePaymentIntent() {
-    return localStorage.getItem('paymentIntent_client_secret');
   }
 
   // Manipulate the DOM to display the payment summary on the right panel.

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -82,6 +82,35 @@ class Store {
     }
   }
 
+  // Create the PaymentIntent with the cart details.
+  async updatePaymentIntentWithShippingCost(
+    paymentIntent,
+    items,
+    shippingOption
+  ) {
+    try {
+      const response = await fetch(
+        `/payment_intents/${paymentIntent}/shipping_change`,
+        {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            shippingOption,
+            items,
+          }),
+        }
+      );
+      const data = await response.json();
+      if (data.error) {
+        return {error: data.error};
+      } else {
+        return data;
+      }
+    } catch (err) {
+      return {error: err.message};
+    }
+  }
+
   // Format a price (assuming a two-decimal currency like EUR or USD for simplicity).
   formatPrice(amount, currency) {
     let price = (amount / 100).toFixed(2);

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -13,6 +13,7 @@ class Store {
   constructor() {
     this.lineItems = [];
     this.products = {};
+    this.productsFetchPromise = null;
     this.displayPaymentSummary();
   }
 
@@ -54,10 +55,16 @@ class Store {
   }
 
   // Load the product details.
-  async loadProducts() {
-    const productsResponse = await fetch('/products');
-    const products = (await productsResponse.json()).data;
-    products.forEach(product => (this.products[product.id] = product));
+  loadProducts() {
+    if (!this.productsFetchPromise) {
+      this.productsFetchPromise = new Promise(async resolve => {
+        const productsResponse = await fetch('/products');
+        const products = (await productsResponse.json()).data;
+        products.forEach(product => (this.products[product.id] = product));
+        resolve();
+      });
+    }
+    return this.productsFetchPromise;
   }
 
   // Create the PaymentIntent with the cart details.

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -150,7 +150,6 @@ class Store {
     const total = this.formatPrice(this.getPaymentTotal(), currency);
     orderTotal.querySelector('[data-subtotal]').innerText = total;
     orderTotal.querySelector('[data-total]').innerText = total;
-    document.getElementById('main').classList.remove('loading');
   }
 }
 

--- a/public/stylesheets/store.css
+++ b/public/stylesheets/store.css
@@ -680,7 +680,11 @@ button:active {
 }
 
 .card-number {
-  font-weight: bold;
+  padding-left: 8px;
+  white-space: nowrap;
+  font-family: Source Code Pro, monospace;
+  color: #0d2b3e;
+  font-weight: 500;
 }
 
 .card-number span {

--- a/public/stylesheets/store.css
+++ b/public/stylesheets/store.css
@@ -664,7 +664,7 @@ button:active {
   color: #666ee8;
 }
 
-#demo p.note {
+#demo .note {
   display: block;
   margin: 10px 0 0;
   font-size: 14px;
@@ -677,6 +677,15 @@ button:active {
 
 #demo p.note a:hover {
   text-decoration: none;
+}
+
+.card-number {
+  font-weight: bold;
+}
+
+.card-number span {
+  display: inline-block;
+  width: 8px;
 }
 
 /* Order Confirmation */

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -6,9 +6,9 @@ This directory contains the main Node implementation of the payments server.
 
 You’ll need the following:
 
-* [Node.js](http://nodejs.org) >= 8.x.
-* Modern browser that supports ES6 (Chrome to see the Payment Request, and Safari to see Apple Pay).
-* Stripe account to accept payments ([sign up](https://dashboard.stripe.com/register) for free).
+- [Node.js](http://nodejs.org) >= 8.x.
+- Modern browser that supports ES6 (Chrome to see the Payment Request, and Safari to see Apple Pay).
+- Stripe account to accept payments ([sign up](https://dashboard.stripe.com/register) for free).
 
 In your Stripe Dashboard, you can [enable the payment methods](https://dashboard.stripe.com/payments/settings) you’d like to test with one click.
 
@@ -26,7 +26,7 @@ Install dependencies using npm:
 
     npm install
 
-This demo uses the Stripe API as a datastore for products and orders, but you can always choose to use your own datastore instead. When starting the app for the first time, the initial loading can take a couple of seconds as it will automatically set up the products within Stripe.
+This demo uses the Stripe API as a datastore for products and SKUs, but you can always choose to use your own datastore instead. When starting the app for the first time, the initial loading can take a couple of seconds as it will automatically set up the products and SKUs within Stripe.
 
 Run the app:
 
@@ -50,4 +50,4 @@ Use this second URL in your browser to start the demo.
 
 ## Credits
 
-* Code: [Romain Huet](https://twitter.com/romainhuet) and [Thorsten Schaeff](https://twitter.com/schaeff_t)
+- Code: [Romain Huet](https://twitter.com/romainhuet) and [Thorsten Schaeff](https://twitter.com/schaeff_t)

--- a/server/node/config.js
+++ b/server/node/config.js
@@ -1,6 +1,7 @@
 /**
  * config.js
- * Stripe Payments Demo. Created by Romain Huet (@romainhuet).
+ * Stripe Payments Demo. Created by Romain Huet (@romainhuet)
+ * and Thorsten Schaeff (@thorwebdev).
  */
 
 'use strict';

--- a/server/node/config.js
+++ b/server/node/config.js
@@ -14,9 +14,24 @@ module.exports = {
   country: 'US',
 
   // Store currency.
-  // Note: A few payment methods like iDEAL or SOFORT only work with euros,
-  // so it's a good common denominator to test both Elements and Sources.
   currency: 'eur',
+
+  // Supported payment methods for the store.
+  // Some payment methods support only a subset of currencies.
+  // Make sure to check the docs: https://stripe.com/docs/sources
+  paymentMethods: [
+    // 'ach_credit_transfer', // usd (ACH Credit Transfer payments must be in U.S. Dollars)
+    'alipay', // Can be aud, cad, eur, gbp, hkd, jpy, nzd, sgd, or usd.
+    'bancontact', // eur (Bancontact must always use Euros)
+    'card', // many (https://stripe.com/docs/currencies#presentment-currencies)
+    'eps', // eur (EPS must always use Euros)
+    'ideal', // eur (iDEAL must always use Euros)
+    'giropay', // eur (Giropay must always use Euros)
+    'multibanco', // eur (Multibanco must always use Euros)
+    // 'sepa_debit', // Restricted. See docs for activation details: https://stripe.com/docs/sources/sepa-debit
+    'sofort', // eur (SOFORT must always use Euros)
+    'wechat', // Can be aud, cad, eur, gbp, hkd, jpy, sgd, or usd.
+  ],
 
   // Configuration for Stripe.
   // API Keys: https://dashboard.stripe.com/account/apikeys

--- a/server/node/config.js
+++ b/server/node/config.js
@@ -21,7 +21,7 @@ module.exports = {
   // Make sure to check the docs: https://stripe.com/docs/sources
   paymentMethods: [
     // 'ach_credit_transfer', // usd (ACH Credit Transfer payments must be in U.S. Dollars)
-    'alipay', // Can be aud, cad, eur, gbp, hkd, jpy, nzd, sgd, or usd.
+    'alipay', // aud, cad, eur, gbp, hkd, jpy, nzd, sgd, or usd.
     'bancontact', // eur (Bancontact must always use Euros)
     'card', // many (https://stripe.com/docs/currencies#presentment-currencies)
     'eps', // eur (EPS must always use Euros)
@@ -30,7 +30,7 @@ module.exports = {
     'multibanco', // eur (Multibanco must always use Euros)
     // 'sepa_debit', // Restricted. See docs for activation details: https://stripe.com/docs/sources/sepa-debit
     'sofort', // eur (SOFORT must always use Euros)
-    'wechat', // Can be aud, cad, eur, gbp, hkd, jpy, sgd, or usd.
+    'wechat', // aud, cad, eur, gbp, hkd, jpy, sgd, or usd.
   ],
 
   // Configuration for Stripe.
@@ -51,6 +51,22 @@ module.exports = {
     // After creating a webhook, click to reveal details and find your signing secret.
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
   },
+
+  // Shipping options for the Payment Request API.
+  shippingOptions: [
+    {
+      id: 'free',
+      label: 'Free Shipping',
+      detail: 'Delivery within 5 days',
+      amount: 0,
+    },
+    {
+      id: 'express',
+      label: 'Express Shipping',
+      detail: 'Next day delivery',
+      amount: 500,
+    },
+  ],
 
   // Server port.
   port: process.env.PORT || 8000,

--- a/server/node/config.js
+++ b/server/node/config.js
@@ -27,7 +27,7 @@ module.exports = {
     // The two-letter country code of your Stripe account (required for Payment Request).
     country: process.env.STRIPE_ACCOUNT_COUNTRY || 'US',
     // API version to set for this app (Stripe otherwise uses your default account version).
-    apiVersion: '2018-02-06',
+    apiVersion: '2019-02-11',
     // Use your test keys for development and live keys for real charges in production.
     // For non-card payments like iDEAL, live keys will redirect to real banking sites.
     publishableKey: process.env.STRIPE_PUBLISHABLE_KEY,

--- a/server/node/inventory.js
+++ b/server/node/inventory.js
@@ -12,7 +12,8 @@
 
 const config = require('./config');
 const stripe = require('stripe')(config.stripe.secretKey);
-stripe.setApiVersion(config.stripe.apiVersion);
+// For product retrieval and listing set API version to 2018-02-28 so that skus are returned.
+stripe.setApiVersion('2018-02-28');
 
 // List all products.
 const listProducts = async () => {

--- a/server/node/inventory.js
+++ b/server/node/inventory.js
@@ -37,13 +37,11 @@ const productsExist = productList => {
   }, !!productList.data.length);
 };
 
-// Shipping cost.
-const getShippingCost = id => {
-  const shippingCost = {
-    free: 0,
-    express: 500,
-  };
-  return shippingCost[id];
+// Get shipping cost from config based on selected shipping option.
+const getShippingCost = shippingOption => {
+  return config.shippingOptions.filter(
+    option => option.id === shippingOption
+  )[0].amount;
 };
 
 exports.products = {

--- a/server/node/inventory.js
+++ b/server/node/inventory.js
@@ -1,10 +1,11 @@
 /**
  * inventory.js
- * Stripe Payments Demo. Created by Romain Huet (@romainhuet).
+ * Stripe Payments Demo. Created by Romain Huet (@romainhuet)
+ * and Thorsten Schaeff (@thorwebdev).
  *
- * Simple library to store and interact with orders and products.
- * These methods are using the Stripe Orders API, but we tried to abstract them
- * from the main code if you'd like to use your own order management system instead.
+ * Simple library to store and interact with products stored on Stripe.
+ * These methods are using the Stripe Products API, but we tried to abstract them
+ * from the main code if you'd like to use your own product management system instead.
  */
 
 'use strict';
@@ -12,48 +13,6 @@
 const config = require('./config');
 const stripe = require('stripe')(config.stripe.secretKey);
 stripe.setApiVersion(config.stripe.apiVersion);
-
-// Create an order.
-const createOrder = async (currency, items, email, shipping, createIntent) => {
-  // Create order
-  let order = await stripe.orders.create({
-    currency,
-    items,
-    email,
-    shipping,
-    metadata: {
-      status: 'created',
-    },
-  });
-  if (createIntent) {
-    // Create PaymentIntent to represent your customer's intent to pay this order.
-    // Note: PaymentIntents currently only support card sources to enable dynamic authentication:
-    // // https://stripe.com/docs/payments/dynamic-3ds
-    const paymentIntent = await stripe.paymentIntents.create({
-      amount: order.amount,
-      currency: order.currency,
-      metadata: {
-        order: order.id,
-      },
-      allowed_source_types: ['card'],
-    });
-    // Add PaymentIntent to order object so our frontend can access the client_secret.
-    // The client_secret is used on the frontend to confirm the PaymentIntent and create a payment.
-    // Therefore, do not log, store, or append the client_secret to a URL.
-    order.paymentIntent = paymentIntent;
-  }
-  return order;
-};
-
-// Retrieve an order by ID.
-const retrieveOrder = async orderId => {
-  return await stripe.orders.retrieve(orderId);
-};
-
-// Update an order.
-const updateOrder = async (orderId, properties) => {
-  return await stripe.orders.update(orderId, properties);
-};
 
 // List all products.
 const listProducts = async () => {
@@ -75,12 +34,6 @@ const productsExist = productList => {
       validProducts.includes(currentValue.id)
     );
   }, !!productList.data.length);
-};
-
-exports.orders = {
-  create: createOrder,
-  retrieve: retrieveOrder,
-  update: updateOrder,
 };
 
 exports.products = {

--- a/server/node/inventory.js
+++ b/server/node/inventory.js
@@ -37,8 +37,18 @@ const productsExist = productList => {
   }, !!productList.data.length);
 };
 
+// Shipping cost.
+const getShippingCost = id => {
+  const shippingCost = {
+    free: 0,
+    express: 500,
+  };
+  return shippingCost[id];
+};
+
 exports.products = {
   list: listProducts,
   retrieve: retrieveProduct,
   exist: productsExist,
+  getShippingCost,
 };

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -148,7 +148,17 @@ router.post('/webhook', async (req, res) => {
     await stripe.paymentIntents.confirm(paymentIntent.id, {source: source.id});
   }
 
-  // TODO Monitor `source.failed`, `source.canceled`, and `PI.?` events.
+  // Monitor `source.failed` and `source.canceled` events.
+  if (
+    object.object === 'source' &&
+    ['failed', 'canceled'].includes(object.status) &&
+    object.metadata.paymentIntent
+  ) {
+    const source = object;
+    console.log(`🔔  The source ${source.id} failed or timed out.`);
+    // Cancel the PaymentIntent.
+    await stripe.paymentIntents.cancel(source.metadata.paymentIntent);
+  }
 
   // Return a 200 success code to Stripe.
   res.sendStatus(200);

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -53,8 +53,19 @@ router.post('/payment_intents', async (req, res, next) => {
     const paymentIntent = await stripe.paymentIntents.create({
       amount,
       currency,
-      allowed_source_types: ['card', 'ideal', 'sepa_debit'], // TODO config
-      return_url: req.headers.origin,
+      allowed_source_types: [
+        // 'ach_credit_transfer', // throws: error: "Invalid currency: eur. The payment method `ach_credit_transfer` only supports the following currencies: usd."
+        'alipay',
+        'bancontact',
+        'card',
+        'eps',
+        'ideal',
+        'giropay',
+        'multibanco',
+        'sepa_debit',
+        'sofort',
+        'wechat',
+      ], // TODO config & gating
     });
     return res.status(200).json({paymentIntent});
   } catch (err) {

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -36,10 +36,14 @@ router.get('/', (req, res) => {
 // Calculate total payment amount based on items in basket.
 const calculatePaymentAmount = async items => {
   const productList = await products.list();
-  const skus = productList.data.reduce((a, c) => [...a, ...c.skus.data], []);
-  const total = items.reduce((a, c) => {
-    const sku = skus.filter(sku => sku.id === c.parent)[0];
-    return a + sku.price * c.quantity;
+  // Look up sku for the item so we can get the current price.
+  const skus = productList.data.reduce(
+    (a, product) => [...a, ...product.skus.data],
+    []
+  );
+  const total = items.reduce((a, item) => {
+    const sku = skus.filter(sku => sku.id === item.parent)[0];
+    return a + sku.price * item.quantity;
   }, 0);
   return total;
 };
@@ -176,6 +180,7 @@ router.get('/config', (req, res) => {
     country: config.country,
     currency: config.currency,
     paymentMethods: config.paymentMethods,
+    shippingOptions: config.shippingOptions,
   });
 });
 

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -1,6 +1,7 @@
 /**
  * routes.js
- * Stripe Payments Demo. Created by Romain Huet (@romainhuet).
+ * Stripe Payments Demo. Created by Romain Huet (@romainhuet)
+ * and Thorsten Schaeff (@thorwebdev).
  *
  * This file defines all the endpoints for this demo app. The two most interesting
  * endpoints for a Stripe integration are marked as such at the beginning of the file.
@@ -11,7 +12,7 @@
 
 const config = require('./config');
 const setup = require('./setup');
-const {orders, products} = require('./inventory');
+const {products} = require('./inventory');
 const express = require('express');
 const router = express.Router();
 const stripe = require('stripe')(config.stripe.secretKey);
@@ -25,70 +26,37 @@ router.get('/', (req, res) => {
 /**
  * Stripe integration to accept all types of payments with 3 POST endpoints.
  *
- * 1. POST endpoint to create orders with all user information.
- * 2. POST endpoint to complete a payment immediately when a card is used.
- * For payments using Elements, Payment Request, Apple Pay, Google Pay, Microsoft Pay.
+ * 1. POST endpoint to create a PaymentIntent.
+ * 2. For payments using Elements, Payment Request, Apple Pay, Google Pay, Microsoft Pay
+ * the PaymentIntent is confirmed automatically with Stripe.js on the client-side.
  * 3. POST endpoint to be set as a webhook endpoint on your Stripe account.
- * It creates a charge as soon as a non-card payment source becomes chargeable.
+ * It confirms the PaymentIntent as soon as a non-card payment source becomes chargeable.
  */
 
-// Create an order on the backend.
-router.post('/orders', async (req, res, next) => {
-  let {currency, items, email, shipping, createIntent} = req.body;
-  try {
-    let order = await orders.create(currency, items, email, shipping, createIntent);
-    return res.status(200).json({order});
-  } catch (err) {
-    return res.status(500).json({error: err.message});
-  }
-});
+// Calculate total payment amount based on items in basket.
+const calculatePaymentAmount = async items => {
+  const products = await stripe.products.list({limit: 3, type: 'good'});
+  const skus = products.data.reduce((a, c) => [...a, ...c.skus.data], []);
+  const total = items.reduce((a, c) => {
+    const sku = skus.filter(sku => sku.id === c.parent)[0];
+    return a + sku.price * c.quantity;
+  }, 0);
+  return total;
+};
 
-// Complete payment for an order using a source.
-router.post('/orders/:id/pay', async (req, res, next) => {
-  let {source} = req.body;
+// Create the PaymentIntent on the backend.
+router.post('/payment_intents', async (req, res, next) => {
+  let {currency, items} = req.body;
+  const amount = await calculatePaymentAmount(items);
+
   try {
-    // Retrieve the order associated to the ID.
-    let order = await orders.retrieve(req.params.id);
-    // Verify that this order actually needs to be paid.
-    if (
-      order.metadata.status === 'pending' ||
-      order.metadata.status === 'paid'
-    ) {
-      return res.status(403).json({order, source});
-    }
-    // Pay the order using the Stripe source.
-    if (source && source.status === 'chargeable') {
-      let charge, status;
-      try {
-        charge = await stripe.charges.create(
-          {
-            source: source.id,
-            amount: order.amount,
-            currency: order.currency,
-            receipt_email: order.email,
-          },
-          {
-            // Set a unique idempotency key based on the order ID.
-            // This is to avoid any race conditions with your webhook handler.
-            idempotency_key: order.id,
-          }
-        );
-      } catch (err) {
-        // This is where you handle declines and errors.
-        // For the demo we simply set to failed.
-        status = 'failed';
-      }
-      if (charge && charge.status === 'succeeded') {
-        status = 'paid';
-      } else if (charge) {
-        status = charge.status;
-      } else {
-        status = 'failed';
-      }
-      // Update the order with the charge status.
-      order = await orders.update(order.id, {metadata: {status}});
-    }
-    return res.status(200).json({order, source});
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount,
+      currency,
+      allowed_source_types: ['card', 'ideal', 'sepa_debit'], // TODO config
+      return_url: req.headers.origin,
+    });
+    return res.status(200).json({paymentIntent});
   } catch (err) {
     return res.status(500).json({error: err.message});
   }
@@ -124,21 +92,26 @@ router.post('/webhook', async (req, res) => {
   }
   const object = data.object;
 
-  // PaymentIntent Beta, see https://stripe.com/docs/payments/payment-intents 
+  // PaymentIntent Beta, see https://stripe.com/docs/payments/payment-intents
   // Monitor payment_intent.succeeded & payment_intent.payment_failed events.
-  if (
-    object.object === 'payment_intent' &&
-    object.metadata.order
-  ) {
+  if (object.object === 'payment_intent' && object.metadata.order) {
     const paymentIntent = object;
     // Find the corresponding order this source is for by looking in its metadata.
     const order = await orders.retrieve(paymentIntent.metadata.order);
     if (eventType === 'payment_intent.succeeded') {
-      console.log(`🔔  Webhook received! Payment for PaymentIntent ${paymentIntent.id} succeeded.`);
+      console.log(
+        `🔔  Webhook received! Payment for PaymentIntent ${
+          paymentIntent.id
+        } succeeded.`
+      );
       // Update the order status to mark it as paid.
       await orders.update(order.id, {metadata: {status: 'paid'}});
     } else if (eventType === 'payment_intent.payment_failed') {
-      console.log(`🔔  Webhook received! Payment on source ${paymentIntent.last_payment_error.source.id} for PaymentIntent ${paymentIntent.id} failed.`);
+      console.log(
+        `🔔  Webhook received! Payment on source ${
+          paymentIntent.last_payment_error.source.id
+        } for PaymentIntent ${paymentIntent.id} failed.`
+      );
       // Note: you can use the existing PaymentIntent to prompt your customer to try again by attaching a newly created source:
       // https://stripe.com/docs/payments/payment-intents#lifecycle
     }
@@ -148,96 +121,30 @@ router.post('/webhook', async (req, res) => {
   if (
     object.object === 'source' &&
     object.status === 'chargeable' &&
-    object.metadata.order
+    object.metadata.paymentIntent
   ) {
     const source = object;
     console.log(`🔔  Webhook received! The source ${source.id} is chargeable.`);
-    // Find the corresponding order this source is for by looking in its metadata.
-    const order = await orders.retrieve(source.metadata.order);
-    // Verify that this order actually needs to be paid.
-    if (
-      order.metadata.status === 'pending' ||
-      order.metadata.status === 'paid' ||
-      order.metadata.status === 'failed'
-    ) {
+    // Find the corresponding PaymentIntent this source is for by looking in its metadata.
+    const paymentIntent = await stripe.paymentIntents.retrieve(
+      source.metadata.paymentIntent
+    );
+    // Check whether this PaymentIntent requires a source.
+    if (paymentIntent.status != 'requires_source') {
       return res.sendStatus(403);
     }
-
-    // Note: We're setting an idempotency key below on the charge creation to
-    // prevent any race conditions. It's set to the order ID, which protects us from
-    // 2 different sources becoming `chargeable` simultaneously for the same order ID.
-    // Depending on your use cases and your idempotency keys, you might need an extra
-    // lock surrounding your webhook code to prevent other race conditions.
-    // Read more on Stripe's best practices here for asynchronous charge creation:
-    // https://stripe.com/docs/sources/best-practices#charge-creation
-
-    // Pay the order using the source we just received.
-    let charge, status;
-    try {
-      charge = await stripe.charges.create(
-        {
-          source: source.id,
-          amount: order.amount,
-          currency: order.currency,
-          receipt_email: order.email,
-        },
-        {
-          // Set a unique idempotency key based on the order ID.
-          // This is to avoid any race conditions with your webhook handler.
-          idempotency_key: order.id,
-        }
-      );
-    } catch (err) {
-      // This is where you handle declines and errors.
-      // For the demo, we simply set the status to mark the order as failed.
-      status = 'failed';
-    }
-    if (charge && charge.status === 'succeeded') {
-      status = 'paid';
-    } else if (charge) {
-      status = charge.status;
-    } else {
-      status = 'failed';
-    }
-    // Update the order status based on the charge status.
-    await orders.update(order.id, {metadata: {status}});
+    // Confirm the PaymentIntent with the chargeable source.
+    await stripe.paymentIntents.confirm(paymentIntent.id, {source: source.id});
   }
 
-  // Monitor `charge.succeeded` events.
-  if (
-    object.object === 'charge' &&
-    object.status === 'succeeded' &&
-    object.source.metadata.order
-  ) {
-    const charge = object;
-    console.log(`🔔  Webhook received! The charge ${charge.id} succeeded.`);
-    // Find the corresponding order this source is for by looking in its metadata.
-    const order = await orders.retrieve(charge.source.metadata.order);
-    // Update the order status to mark it as paid.
-    await orders.update(order.id, {metadata: {status: 'paid'}});
-  }
-
-  // Monitor `source.failed`, `source.canceled`, and `charge.failed` events.
-  if (
-    (object.object === 'source' || object.object === 'charge') &&
-    (object.status === 'failed' || object.status === 'canceled')
-  ) {
-    const source = object.source ? object.source : object;
-    console.log(`🔔  Webhook received! Failure for ${object.id}.`);
-    if (source.metadata.order) {
-      // Find the corresponding order this source is for by looking in its metadata.
-      const order = await orders.retrieve(source.metadata.order);
-      // Update the order status to mark it as failed.
-      await orders.update(order.id, {metadata: {status: 'failed'}});
-    }
-  }
+  // TODO Monitor `source.failed`, `source.canceled`, and `PI.?` events.
 
   // Return a 200 success code to Stripe.
   res.sendStatus(200);
 });
 
 /**
- * Routes exposing the config as well as the ability to retrieve products and orders.
+ * Routes exposing the config as well as the ability to retrieve products.
  */
 
 // Expose the Stripe publishable key and other pieces of config via an endpoint.
@@ -248,15 +155,6 @@ router.get('/config', (req, res) => {
     country: config.country,
     currency: config.currency,
   });
-});
-
-// Retrieve an order.
-router.get('/orders/:id', async (req, res) => {
-  try {
-    return res.status(200).json(await orders.retrieve(req.params.id));
-  } catch (err) {
-    return res.sendStatus(404);
-  }
 });
 
 // Retrieve all products.

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -53,19 +53,7 @@ router.post('/payment_intents', async (req, res, next) => {
     const paymentIntent = await stripe.paymentIntents.create({
       amount,
       currency,
-      payment_method_types: [
-        // 'ach_credit_transfer', // throws: error: "Invalid currency: eur. The payment method `ach_credit_transfer` only supports the following currencies: usd."
-        'alipay',
-        'bancontact',
-        'card',
-        'eps',
-        'ideal',
-        'giropay',
-        'multibanco',
-        'sepa_debit',
-        'sofort',
-        'wechat',
-      ], // TODO config & gating
+      payment_method_types: config.paymentMethods,
     });
     return res.status(200).json({paymentIntent});
   } catch (err) {
@@ -177,6 +165,7 @@ router.get('/config', (req, res) => {
     stripeCountry: config.stripe.country,
     country: config.country,
     currency: config.currency,
+    paymentMethods: config.paymentMethods,
   });
 });
 

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -182,4 +182,10 @@ router.get('/products/:id', async (req, res) => {
   res.json(await products.retrieve(req.params.id));
 });
 
+// Retrieve the PaymentIntent status.
+router.get('/payment_intents/:id/status', async (req, res) => {
+  const paymentIntent = await stripe.paymentIntents.retrieve(req.params.id);
+  res.json({paymentIntent: {status: paymentIntent.status}});
+});
+
 module.exports = router;

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -105,18 +105,14 @@ router.post('/webhook', async (req, res) => {
 
   // PaymentIntent Beta, see https://stripe.com/docs/payments/payment-intents
   // Monitor payment_intent.succeeded & payment_intent.payment_failed events.
-  if (object.object === 'payment_intent' && object.metadata.order) {
+  if (object.object === 'payment_intent') {
     const paymentIntent = object;
-    // Find the corresponding order this source is for by looking in its metadata.
-    const order = await orders.retrieve(paymentIntent.metadata.order);
     if (eventType === 'payment_intent.succeeded') {
       console.log(
         `🔔  Webhook received! Payment for PaymentIntent ${
           paymentIntent.id
         } succeeded.`
       );
-      // Update the order status to mark it as paid.
-      await orders.update(order.id, {metadata: {status: 'paid'}});
     } else if (eventType === 'payment_intent.payment_failed') {
       console.log(
         `🔔  Webhook received! Payment on source ${

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -73,6 +73,22 @@ router.post('/payment_intents', async (req, res, next) => {
   }
 });
 
+// Update PaymentIntent with shipping cost.
+router.post('/payment_intents/:id/shipping_change', async (req, res, next) => {
+  const {items, shippingOption} = req.body;
+  let amount = await calculatePaymentAmount(items);
+  amount += products.getShippingCost(shippingOption.id);
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.update(req.params.id, {
+      amount,
+    });
+    return res.status(200).json({paymentIntent});
+  } catch (err) {
+    return res.status(500).json({error: err.message});
+  }
+});
+
 // Webhook handler to process payments for sources asynchronously.
 router.post('/webhook', async (req, res) => {
   let data;

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -1,6 +1,7 @@
 /**
  * server.js
- * Stripe Payments Demo. Created by Romain Huet (@romainhuet).
+ * Stripe Payments Demo. Created by Romain Huet (@romainhuet)
+ * and Thorsten Schaeff (@thorwebdev).
  *
  * This is the main file starting the Express server for the demo and enabling ngrok.
  */

--- a/server/node/setup.js
+++ b/server/node/setup.js
@@ -1,10 +1,10 @@
 /**
  * setup.js
- * Stripe Payments Demo. Created by Romain Huet (@romainhuet).
+ * Stripe Payments Demo. Created by Romain Huet (@romainhuet)
+ * and Thorsten Schaeff (@thorwebdev).
  *
  * This is a one-time setup script for your server. It creates a set of fixtures,
- * namely products and SKUs, that can then used to create orders when completing the
- * checkout flow in the web interface.
+ * namely products and SKUs, that are used to create a random basket session.
  */
 
 'use strict';

--- a/server/python/README.md
+++ b/server/python/README.md
@@ -4,19 +4,19 @@ This demo uses a simple [Flask](http://flask.pocoo.org/) application as the serv
 
 ## Payments Integration
 
-* [`app.py`](app.py) contains the routes that interface with Stripe to create charges and receive webhook events.
-* [`setup.py`](setup.py) a simple setup script to make some fake Products and SKUs for our Stripe store.
-* [`tests/tests.py`](tests/tests.py) some unit tests that test the logic of our heavier APIs like `orders/<string:id>/pay` and `/webhook`.
-* [`test_data.py`](tests/tests.py) contains some hardcoded mocked responses to test with.
-* [`inventory_manager.py`](stripe_lib.py) a minimal wrapper over the Stripe Python SDK that handles creating/fetching orders and products. You can override this class with your own order management system code.
+- [`app.py`](app.py) contains the routes that interface with Stripe to create charges and receive webhook events.
+- [`setup.py`](setup.py) a simple setup script to make some fake Products and SKUs for our Stripe store.
+- [`tests/tests.py`](tests/tests.py) some unit tests that test the logic of our heavier APIs like `/webhook`.
+- [`test_data.py`](tests/tests.py) contains some hardcoded mocked responses to test with.
+- [`inventory_manager.py`](stripe_lib.py) a minimal wrapper over the Stripe Python SDK that handles creating/fetching products and caluclating payment amounts from SKUs. You can override this class with your own product and order management system code.
 
 ## Requirements
 
 You’ll need the following:
 
-* [Python 3.6.5](https://www.python.org/downloads/release/python-365/)
-* Modern browser that supports ES6 (Chrome to see the Payment Request, and Safari to see Apple Pay).
-* Stripe account to accept payments ([sign up](https://dashboard.stripe.com/register) for free!)
+- [Python 3.6.5](https://www.python.org/downloads/release/python-365/)
+- Modern browser that supports ES6 (Chrome to see the Payment Request, and Safari to see Apple Pay).
+- Stripe account to accept payments ([sign up](https://dashboard.stripe.com/register) for free!)
 
 ## Getting Started
 
@@ -87,4 +87,4 @@ python tests.py
 
 ## Credits
 
-* Code: [Adrienne Dreyfus](http://twitter.com/adrind)
+- Code: [Adrienne Dreyfus](http://twitter.com/adrind)

--- a/server/python/README.md
+++ b/server/python/README.md
@@ -4,11 +4,11 @@ This demo uses a simple [Flask](http://flask.pocoo.org/) application as the serv
 
 ## Payments Integration
 
-- [`app.py`](app.py) contains the routes that interface with Stripe to create charges and receive webhook events.
+- [`app.py`](app.py) contains the routes that interface with Stripe to create PaymentIntents and receive webhook events.
 - [`setup.py`](setup.py) a simple setup script to make some fake Products and SKUs for our Stripe store.
 - [`tests/tests.py`](tests/tests.py) some unit tests that test the logic of our heavier APIs like `/webhook`.
 - [`test_data.py`](tests/tests.py) contains some hardcoded mocked responses to test with.
-- [`inventory_manager.py`](stripe_lib.py) a minimal wrapper over the Stripe Python SDK that handles creating/fetching products and caluclating payment amounts from SKUs. You can override this class with your own product and order management system code.
+- [`inventory.py`](stripe_lib.py) a minimal wrapper over the Stripe Python SDK that handles creating/fetching products and caluclating payment amounts. You can override this class with your own product and order management system code.
 
 ## Requirements
 

--- a/server/python/app.py
+++ b/server/python/app.py
@@ -54,7 +54,21 @@ def get_config():
         'stripeCountry': os.getenv('STRIPE_ACCOUNT_COUNTRY') or 'US',
         'country': 'US',
         'currency': 'eur',
-        'paymentMethods': os.getenv('PAYMENT_METHODS').split(', ') if os.getenv('PAYMENT_METHODS') else ['card']
+        'paymentMethods': os.getenv('PAYMENT_METHODS').split(', ') if os.getenv('PAYMENT_METHODS') else ['card'],
+        'shippingOptions': [
+        {
+            'id': 'free',
+            'label': 'Free Shipping',
+            'detail': 'Delivery within 5 days',
+            'amount': 0,
+        },
+        {
+            'id': 'express',
+            'label': 'Express Shipping',
+            'detail': 'Next day delivery',
+            'amount': 500,
+        }
+        ]
     })
 
 

--- a/server/python/app.py
+++ b/server/python/app.py
@@ -54,7 +54,7 @@ def get_config():
         'stripeCountry': os.getenv('STRIPE_ACCOUNT_COUNTRY') or 'US',
         'country': 'US',
         'currency': 'eur',
-        'paymentMethods': os.getenv('PAYMENT_METHODS').split(', ') or ['card']
+        'paymentMethods': os.getenv('PAYMENT_METHODS').split(', ') if os.getenv('PAYMENT_METHODS') else ['card']
     })
 
 
@@ -84,7 +84,8 @@ def make_payment_intent():
             amount=Inventory.calculate_payment_amount(items=data['items']),
             currency=data['currency'],
             payment_method_types=os.getenv(
-                'PAYMENT_METHODS').split(', ') or ['card']
+                'PAYMENT_METHODS').split(', ') if os.getenv(
+                'PAYMENT_METHODS') else ['card']
         )
 
         return jsonify({'paymentIntent': payment_intent})

--- a/server/python/app.py
+++ b/server/python/app.py
@@ -5,7 +5,7 @@ app.py
 Stripe Payments Demo. Created by Adrienne Dreyfus (@adrind).
 
 This is our Flask server that handles requests from our Stripe checkout flow.
-It has all the endpoints you need to accept payments and manage orders.
+It has all the endpoints you need to accept payments.
 
 Python 3.6 or newer required.
 """
@@ -16,7 +16,7 @@ import setup
 import os
 
 from inventory import Inventory
-from stripe_types import Source, Order
+from stripe_types import Source
 from flask import Flask, render_template, jsonify, request, send_from_directory
 from dotenv import load_dotenv, find_dotenv
 
@@ -53,7 +53,8 @@ def get_config():
         'stripePublishableKey': os.getenv('STRIPE_PUBLISHABLE_KEY'),
         'stripeCountry': os.getenv('STRIPE_ACCOUNT_COUNTRY') or 'US',
         'country': 'US',
-        'currency': 'eur'
+        'currency': 'eur',
+        'paymentMethods': os.getenv('PAYMENT_METHODS').split(', ') or ['card']
     })
 
 
@@ -74,51 +75,37 @@ def retrieve_product(product_id):
     return jsonify(Inventory.retrieve_product(product_id))
 
 
-@app.route('/orders', methods=['POST'])
-def make_order():
-    # Creates a new Order with items that the user selected.
+@app.route('/payment_intents', methods=['POST'])
+def make_payment_intent():
+    # Creates a new PaymentIntent with items from the cart.
     data = json.loads(request.data)
     try:
-        order = Inventory.create_order(currency=data['currency'], items=data['items'], email=data['email'],
-                                       shipping=data['shipping'], create_intent=data['createIntent'])
+        payment_intent = stripe.PaymentIntent.create(
+            amount=Inventory.calculate_payment_amount(items=data['items']),
+            currency=data['currency'],
+            payment_method_types=os.getenv(
+                'PAYMENT_METHODS').split(', ') or ['card']
+        )
 
-        return jsonify({'order': order})
+        return jsonify({'paymentIntent': payment_intent})
     except Exception as e:
         return jsonify(e), 403
 
 
-@app.route('/orders/<string:order_id>/pay', methods=['POST'])
-def pay_order(order_id):
-    """
-    Creates a Charge for an Order using a payment Source provided by the user.
-    """
-
+@app.route('/payment_intents/<string:id>/shipping_change', methods=['POST'])
+def update_payment_intent(id):
     data = json.loads(request.data)
-    source = data['source']
+    amount = Inventory.calculate_payment_amount(items=data['items'])
+    amount += Inventory.get_shipping_cost(data['shippingOption']['id'])
+    try:
+        payment_intent = stripe.PaymentIntent.modify(
+            id,
+            amount=amount
+        )
 
-    order = Inventory.retrieve_order(order_id)
-
-    if order['metadata']['status'] == 'pending' or order['metadata']['status'] == 'paid':
-        # Somehow this Order has already been paid for -- abandon request.
-        return jsonify({'source': source, 'order': order}), 403
-
-    if source['status'] == 'chargeable':
-        # Yay! Our user gave us a valid payment Source we can charge.
-        charge = stripe.Charge.create(source=source['id'], amount=order['amount'], currency=order['currency'],
-                                      receipt_email=order['email'], idempotency_key=order['id'])
-
-        if charge and charge['status'] == 'succeeded':
-            status = 'paid'
-        elif charge and 'status' in charge:
-            status = charge['status']
-        else:
-            status = 'failed'
-
-        # Update the Order with a new status based on what happened with the Charge.
-        Inventory.update_order(
-            properties={'metadata': {'status': status}}, order=order)
-
-    return jsonify({'order': order, 'source': source})
+        return jsonify({'paymentIntent': payment_intent})
+    except Exception as e:
+        return jsonify(e), 403
 
 
 @app.route('/webhook', methods=['POST'])
@@ -146,9 +133,8 @@ def webhook_received():
 
     # PaymentIntent Beta, see https://stripe.com/docs/payments/payment-intents
     # Monitor payment_intent.succeeded & payment_intent.payment_failed events.
-    if data_object['object'] == 'payment_intent' and 'order' in data_object['metadata']:
+    if data_object['object'] == 'payment_intent':
         payment_intent = data_object
-        order = stripe.Order.retrieve(payment_intent['metadata']['order'])
 
         if event_type == 'payment_intent.succeeded':
             print('🔔  Webhook received! Payment for PaymentIntent ' +
@@ -160,61 +146,40 @@ def webhook_received():
     # Monitor `source.chargeable` events.
     if data_object['object'] == 'source' \
             and data_object['status'] == 'chargeable' \
-            and 'order' in data_object['metadata']:
+            and 'paymentIntent' in data_object['metadata']:
         source = data_object
-        print(f'Webhook received! The source {source["id"]} is chargeable')
+        print(f'🔔  Webhook received! The source {source["id"]} is chargeable')
 
-        # Find the corresponding Order this Source is for by looking in its metadata.
-        order = Inventory.retrieve_order(source['metadata']['order'])
+        # Find the corresponding PaymentIntent this Source is for by looking in its metadata.
+        payment_intent = stripe.PaymentIntent.retrieve(
+            source['metadata']['paymentIntent'])
 
-        # Verify that this Order actually needs to be paid.
-        order_status = order['metadata']['status']
-        if order_status in ['pending', 'paid', 'failed']:
-            return jsonify({'error': f'Order already has a status of {order_status}'}), 403
+        # Verify that this PaymentIntent actually needs to be paid.
+        if payment_intent['status'] != 'requires_payment_method':
+            return jsonify({'error': f'PaymentIntent already has a status of {payment_intent["status"]}'}), 403
 
-        # Create a Charge to pay the Order using the Source we just received.
-        try:
-            charge = stripe.Charge.create(source=source['id'], amount=order['amount'], currency=order['currency'],
-                                          receipt_email=order['email'], idempotency_key=order['id'])
+        # Confirm the PaymentIntent with the chargeable source.
+        payment_intent.confirm(source=source['id'])
 
-            if charge and charge['status'] == 'succeeded':
-                status = 'paid'
-            elif charge:
-                status = charge['status']
-            else:
-                status = 'failed'
-
-        except stripe.error.CardError:
-            # This is where you handle declines and errors.
-            # For the demo, we simply set the status to mark the Order as failed.
-            status = 'failed'
-
-        Inventory.update_order(
-            properties={'metadata': {'status': status}}, order=order)
-
-    # Monitor `charge.succeeded` events.
-    if data_object['object'] == 'charge' \
-            and data_object['status'] == 'succeeded' \
-            and 'order' in data_object['source']['metadata']:
-        charge = data_object
-        print(f'Webhook received! The charge {charge["id"]} succeeded.')
-        Inventory.update_order(properties={'metadata': {'status': 'paid'}},
-                               order_id=charge['source']['metadata']['order'])
-
-    # Monitor `source.failed`, `source.canceled`, and `charge.failed` events.
-    if data_object['object'] in ['source', 'charge'] and data_object['status'] in ['failed', 'canceled']:
-        source = data_object['source'] if data_object['source'] else data_object
-        print(f'Webhook received! Failure for {data_object["id"]}.`')
-
-        if source['metadata']['order']:
-            Inventory.update_order(properties={'metadata': {'status': 'failed'}},
-                                   order_id=source['metadata']['order']['id'])
+    # Monitor `source.failed` and `source.canceled` events.
+    if data_object['object'] == 'source' and data_object['status'] in ['failed', 'canceled']:
+        # Cancel the PaymentIntent.
+        source = data_object
+        intent = stripe.PaymentIntent.retrieve(
+            source['metadata']['paymentIntent'])
+        intent.cancel()
 
     return jsonify({'status': 'success'})
+
+
+@app.route('/payment_intents/<string:id>/status', methods=['GET'])
+def retrieve_payment_intent_status(id):
+    payment_intent = stripe.PaymentIntent.retrieve(id)
+    return jsonify({'paymentIntent': {'status': payment_intent["status"]}})
 
 
 if __name__ == '__main__':
     load_dotenv(find_dotenv())
     stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
-    stripe.api_version = '2018-02-06'
+    stripe.api_version = '2019-02-11'
     app.run()

--- a/server/python/inventory.py
+++ b/server/python/inventory.py
@@ -38,6 +38,7 @@ class Inventory:
 
     @staticmethod
     def get_shipping_cost(id) -> int:
+        # This would be a lookup in your database to get the shipping prices
         shipping_cost = {'free': 0, 'express': 500}
         return shipping_cost[id]
 

--- a/server/python/inventory.py
+++ b/server/python/inventory.py
@@ -18,12 +18,15 @@ load_dotenv(find_dotenv())
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
 stripe.api_version = '2019-02-11'
 
+# For product retrieval and listing set API version to 2018-02-28 so that skus are returned.
+product_api_stripe_version = '2018-02-28'
+
 
 class Inventory:
     @staticmethod
     def calculate_payment_amount(items: list) -> int:
         product_list = stripe.Product.list(
-            limit=3, stripe_version='2018-02-28')
+            limit=3, stripe_version=product_api_stripe_version)
         product_list_data = product_list['data']
         total = 0
         for item in items:
@@ -40,11 +43,11 @@ class Inventory:
 
     @staticmethod
     def list_products() -> [Product]:
-        return stripe.Product.list(limit=3, stripe_version='2018-02-28')
+        return stripe.Product.list(limit=3, stripe_version=product_api_stripe_version)
 
     @staticmethod
     def retrieve_product(product_id) -> Product:
-        return stripe.Product.retrieve(product_id, stripe_version='2018-02-28')
+        return stripe.Product.retrieve(product_id, stripe_version=product_api_stripe_version)
 
     @staticmethod
     def products_exist(product_list: [Product]) -> bool:

--- a/server/python/inventory.py
+++ b/server/python/inventory.py
@@ -2,61 +2,49 @@
 inventory.py
 Stripe Payments Demo. Created by Adrienne Dreyfus (@adrind).
 
-Simple library to store and interact with orders and products.
-These methods are using the Stripe Orders API, but we tried to abstract them
-from the main code if you'd like to use your own order management system instead.
+Simple library to store and interact with products and SKUs.
+These methods are using the Stripe Product API, but we tried to abstract them
+from the main code if you'd like to use your own product and order management system instead.
 """
 
 import stripe
 import os
 from functools import reduce
-from stripe_types import Order, Product
+from stripe_types import Product
 from dotenv import load_dotenv, find_dotenv
 
 load_dotenv(find_dotenv())
 
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
-stripe.api_version = '2018-02-06'
+stripe.api_version = '2019-02-11'
 
 
 class Inventory:
     @staticmethod
-    def create_order(currency: str, items: list, email: str, shipping: dict, create_intent: bool) -> Order:
-        order = stripe.Order.create(currency=currency, items=items,
-                                    email=email, shipping=shipping, metadata={'status': 'created'})
-        if create_intent:
-            # Create PaymentIntent to represent customers intent to pay this order.
-            # Note: PaymentIntents currently only support card sources to enable dynamic authentication:
-            # https://stripe.com/docs/payments/dynamic-authentication
-            payment_intent = stripe.PaymentIntent.create(
-                amount=order['amount'], currency=currency, metadata={'order': order['id']}, allowed_source_types=['card'])
-            # Add PaymentIntent to order object so our frontend can access the client_secret.
-            # The client_secret is used on the frontend to confirm the PaymentIntent and create a payment.
-            # Therefore, do not log, store, or append the client_secret to a URL.
-            order['paymentIntent'] = payment_intent
-        return order
+    def calculate_payment_amount(items: list) -> int:
+        product_list = stripe.Product.list(
+            limit=3, stripe_version='2018-02-28')
+        product_list_data = product_list['data']
+        total = 0
+        for item in items:
+            sku_id = item['parent']
+            product = next(
+                filter(lambda p: p['skus']['data'][0]['id'] == sku_id, product_list_data))
+            total += (product['skus']['data'][0]['price'] * item['quantity'])
+        return total
 
     @staticmethod
-    def retrieve_order(order_id: str) -> Order:
-        return stripe.Order.retrieve(order_id)
-
-    @staticmethod
-    def update_order(properties: dict, order: Order = None, order_id: str = None) -> Order:
-        if not order:
-            if not order_id:
-                print('Error when fetching order -- no id or object given')
-            order = Inventory.retrieve_order(order_id)
-
-        order.update(properties)
-        return order
+    def get_shipping_cost(id) -> int:
+        shipping_cost = {'free': 0, 'express': 500}
+        return shipping_cost[id]
 
     @staticmethod
     def list_products() -> [Product]:
-        return stripe.Product.list(limit=3)
+        return stripe.Product.list(limit=3, stripe_version='2018-02-28')
 
     @staticmethod
     def retrieve_product(product_id) -> Product:
-        return stripe.Product.retrieve(product_id)
+        return stripe.Product.retrieve(product_id, stripe_version='2018-02-28')
 
     @staticmethod
     def products_exist(product_list: [Product]) -> bool:

--- a/server/python/setup.py
+++ b/server/python/setup.py
@@ -3,7 +3,7 @@ setup.py
 Stripe Payments Demo. Created by Adrienne Dreyfus (@adrind).
 
 This is a one-time setup script for your server. It creates a set of fixtures,
-namely products and SKUs, that can then used to create orders when completing the
+namely products and SKUs, that can then used to caluclate payment amounts when completing the
 checkout flow in the web interface.
 """
 
@@ -14,13 +14,14 @@ from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
 stripe.api_key = os.getenv('STRIPE_SECRET_KEY')
-stripe.api_version = '2018-02-06'
+stripe.api_version = '2019-02-11'
 
 
 def create_data():
     try:
         products = [{'id': 'increment', 'type': 'good', 'name': 'Increment Magazine', 'attributes': ['issue']},
-                    {'id': 'pins', 'type': 'good', 'name': 'Stripe Pins', 'attributes': ['set']},
+                    {'id': 'pins', 'type': 'good',
+                        'name': 'Stripe Pins', 'attributes': ['set']},
                     {'id': 'shirt', 'type': 'good', 'name': 'Stripe Shirt', 'attributes': ['size', 'gender']}]
 
         for product in products:

--- a/server/python/stripe_types.py
+++ b/server/python/stripe_types.py
@@ -2,9 +2,7 @@
 
 # https://stripe.com/docs/api#sources
 Source = dict
-# https://stripe.com/docs/api#orders
-Order = dict
 # https://stripe.com/docs/api#service_products
 Product = dict
-#https://stripe.com/docs/api#charges
+# https://stripe.com/docs/api#charges
 Charge = dict

--- a/server/python/tests/test_data.py
+++ b/server/python/tests/test_data.py
@@ -4,115 +4,60 @@ import copy
 # Most was taken from the webhooks portion of the Dashboard.
 # https://dashboard.stripe.com/account/webhooks
 
-mocked_created_order = {
-    "id": "or_1CGAuMLz2oBaUePUHh3z2EQ4",
-    "object": "order",
-    "amount": 444,
-    "charge": None,
-    "created": 1523560594,
-    "currency": "usd",
-    "metadata": {"status": "created"},
-    "redirect": "",
-    "email": "me@cooldomain.com"
-}
-
-mocked_pending_order = copy.deepcopy(mocked_created_order)
-mocked_pending_order['metadata']['status'] = 'pending'
-mocked_failed_order = copy.deepcopy(mocked_created_order)
-mocked_failed_order['metadata']['status'] = 'failed'
-mocked_paid_order = copy.deepcopy(mocked_created_order)
-mocked_paid_order['metadata']['status'] = 'paid'
-
-mocked_source_chargeable_webhook_request = {
-    "created": 1326853478,
-    "livemode": False,
-    "id": "evt_00000000000000",
-    "type": "source.chargeable",
-    "object": "event",
-    "data": {"object": {"id": "src_00000000000000",
-                        "object": "source", "amount": None,
-                        "client_secret": "src_client_secret_CfY0xjFvOkWpM4XeFBrSEUE8",
-                        "created": 1523568262, "currency": "usd", "flow": "receiver", "livemode": False,
-                        "metadata": {}, "owner": {"address": None, "email": "jenny.rosen@example.com", "name": None,
-                                                  "phone": None, "verified_address": None, "verified_email": None,
-                                                  "verified_name": None, "verified_phone": None},
-                        "receiver": {"address": "121042882-38381234567890123", "amount_charged": 0,
-                                     "amount_received": 0, "amount_returned": 0, "refund_attributes_method": "email",
-                                     "refund_attributes_status": "missing"}, "statement_descriptor": None,
-                        "status": "chargeable", "type": "ach_credit_transfer", "usage": "reusable",
-                        "ach_credit_transfer": {"account_number": "test_52796e3294dc", "routing_number": "110000000",
-                                                "fingerprint": "ecpwEzmBOSMOqQTL", "bank_name": "TEST BANK",
-                                                "swift_code": "TSTEZ122"}}}}
-
-mock_charge_succeeded_webhook_request = copy.deepcopy(mocked_source_chargeable_webhook_request)
-mock_charge_succeeded_webhook_request['type'] = 'charge.succeeded'
-
-mock_source_failed_webhook_request = copy.deepcopy(mocked_source_chargeable_webhook_request)
-mock_charge_succeeded_webhook_request['type'] = 'source.failed'
-
-mocked_source = {
-    "id": "src_1CGAzALz2oBaUePUcDLqBlys",
-    "object": "source",
-    "amount": None,
-    "currency": None,
-    "status": "chargeable",
-    "type": "card",
-    "usage": "reusable",
-    "card": {
-        "exp_month": 4,
-        "exp_year": 2024,
-        "brand": "Visa",
-        "three_d_secure": "not required"
+mock_payment_intent = {
+  "id": "pi_Aabcxyz01aDfoo",
+  "object": "payment_intent",
+  "amount": 1000,
+  "amount_capturable": 1000,
+  "amount_received": 0,
+  "application": None,
+  "application_fee_amount": None,
+  "canceled_at": None,
+  "cancellation_reason": None,
+  "capture_method": "automatic",
+  "charges": {
+    "object": "list",
+    "data": [],
+    "has_more": False,
+    "total_count": 0,
+    "url": "/v1/charges?payment_intent=pi_Aabcxyz01aDfoo"
+  },
+  "client_secret": None,
+  "confirmation_method": "publishable",
+  "created": 123456789,
+  "currency": "usd",
+  "customer": None,
+  "description": "PaymentIntent Description",
+  "last_payment_error": None,
+  "livemode": False,
+  "metadata": {
+    "order_id": "123456789"
+  },
+  "next_action": None,
+  "on_behalf_of": None,
+  "payment_method_types": [
+    "card"
+  ],
+  "receipt_email": "jenny@example.com",
+  "review": None,
+  "shipping": {
+    "address": {
+      "city": "SF",
+      "country": "US",
+      "line1": "123 Main st",
+      "line2": "",
+      "postal_code": "94703",
+      "state": "CA"
     },
-    "livemode": False
+    "carrier": None,
+    "name": "Adrienne Dreyfus",
+    "phone": "+16507047927",
+    "tracking_number": None
+  },
+  "source": "src_1E8u7Q2eZvKYlo2CRRE5r3oQ",
+  "statement_descriptor": "PaymentIntent Statement Descriptor",
+  "status": "succeeded",
+  "transfer_data": None,
+  "transfer_group": None
 }
 
-mocked_charge = {"status": "succeeded"}
-mocked_failed_charge = {"status": "failed"}
-
-mocked_source_chargable_webhook_event = {
-    "created": 1326853478,
-    "livemode": False,
-    "id": "evt_00000000000000",
-    "type": "source.chargeable",
-    "object": "event",
-    "request": None,
-    "pending_webhooks": 1,
-    "api_version": "2018-02-28",
-    "data": {
-        "object": {
-            "id": "src_00000000000000",
-            "object": "source",
-            "amount": None,
-            "client_secret": "src_client_secret_CfYJiBYgEmB9s4Tri7RUWcOa", "created": 1523569400,
-            "currency": "usd", "flow": "receiver", "livemode": False,
-            "owner": {
-                "address": None, "email": "jenny.rosen@example.com", "name": None, "phone": None,
-                "verified_address": None, "verified_email": None, "verified_name": None, "verified_phone": None
-            },
-            "receiver": {
-                "address": "121042882-38381234567890123", "amount_charged": 0,
-                "amount_received": 0, "amount_returned": 0, "refund_attributes_method": "email",
-                "refund_attributes_status": "missing"
-            },
-            "statement_descriptor": None,
-            "status": "chargeable",
-            "type": "ach_credit_transfer",
-            "usage": "reusable",
-            "ach_credit_transfer": {
-                "account_number": "test_52796e3294dc", "routing_number": "110000000", "fingerprint": "ecpwEzmBOSMOqQTL",
-                "bank_name": "TEST BANK", "swift_code": "TSTEZ122"
-            },
-            "metadata": {"order": mocked_created_order}
-        }
-    }
-}
-
-mocked_charge_suceeded_webhook_event = copy.deepcopy(mocked_source_chargable_webhook_event)
-mocked_charge_suceeded_webhook_event['data']['object']['object'] = 'charge'
-mocked_charge_suceeded_webhook_event['data']['object']['status'] = 'succeeded'
-mocked_charge_suceeded_webhook_event['data']['object']['source'] = {'metadata': {"order": mocked_created_order["id"]}}
-
-mocked_source_failed_webhook_event = copy.deepcopy(mocked_source_chargable_webhook_event)
-mocked_source_failed_webhook_event['data']['object']['status'] = 'failed'
-mocked_source_failed_webhook_event['data']['object']['source'] = {'metadata': {"order": mocked_created_order}}


### PR DESCRIPTION
* Switch to PaymentIntents for all payment methods by confirming the PaymentIntent with a chargeable source.
* Remove all dependencies to the orders API.
* Upgrade to API version to 2019-02-11[0]

[0] https://stripe.com/docs/upgrades#2019-02-11