### PR TITLE
WIP - Add stripe tracing

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -218,8 +218,8 @@
         <p class="label">Shipping</p>
         <p class="price">Free</p>
       </div>
-      <div class="line-item demo">
-        <div id="demo">
+      <div id="testmode-info" class="line-item">
+        <div class="demo">
           <p class="label">Demo in test mode</p>
           <p class="note">You can copy and paste the following test cards to trigger different scenarios:</p>
           <table class="note">
@@ -237,10 +237,6 @@
             Non-card payments will redirect to test pages.
           </p>
         </div>
-      </div>
-      <div class="line-item total">
-        <p class="label">Total</p>
-        <p class="price" data-total></p>
       </div>
     </div>
   </div>

--- a/public/index.html
+++ b/public/index.html
@@ -250,6 +250,8 @@
   <script src="https://cdn.rawgit.com/davidshimjs/qrcodejs/gh-pages/qrcode.min.js"></script>
   <!-- App -->
   <script src="/javascripts/store.js"></script>
+  <script src="https://storage.googleapis.com/stripe-tracer-js/aquarium-0.0.3.js"></script>
+  <script src="/javascripts/tracer.js"></script>
   <script src="/javascripts/payments.js"></script>
 </body>
 

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -33,6 +33,12 @@
     betas: ['payment_intent_beta_3'],
   });
 
+  // Trace Stripe Calls
+  if (config.enableTracing) {
+    Tracer.SetupTracingConfig(store);
+    Tracer.TraceStripe(stripe);
+  }
+
   // Create an instance of Elements.
   const elements = stripe.elements();
 

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -11,10 +11,32 @@
 
 class Store {
   constructor() {
+    const url_string = window.location.href;
+    const url = new URL(url_string);
+    this.demoConfig = {
+      // destination | direct | none
+      'aquarium-id': url.searchParams.get('aquarium-id'),
+    };
+
     this.lineItems = [];
     this.products = {};
     this.productsFetchPromise = null;
     this.displayPaymentSummary();
+  }
+
+  getDemoConfig() {
+    return this.demoConfig;
+  }
+
+  updateConfig(configDiff) {
+    let config = Object.assign(this.demoConfig, configDiff);
+    const url_string = window.location.href;
+    const url = new URL(url_string);
+    Object.keys(config).forEach(key => {
+      url.searchParams.set(key, config[key]);
+    });
+    window.history.replaceState('', 'Stripe Payments Demo', url.href);
+    this.demoConfig = config;
   }
 
   // Compute the total for the payment based on the line items (SKUs and quantity).

--- a/public/stylesheets/store.css
+++ b/public/stylesheets/store.css
@@ -652,30 +652,31 @@ button:active {
   line-height: inherit;
 }
 
-#demo {
+.demo {
   padding: 15px;
   margin: -15px -15px 0;
   background: #f6f9fc;
   border-radius: 5px;
+  min-width: 108%;
 }
 
-#demo p.label {
+.demo p.label {
   margin: 0 0 10px;
   color: #666ee8;
 }
 
-#demo .note {
+.demo .note {
   display: block;
   margin: 10px 0 0;
   font-size: 14px;
 }
 
-#demo p.note a,
-#demo p.note em {
+.demo p.note a,
+.demo p.note em {
   font-size: 14px;
 }
 
-#demo p.note a:hover {
+.demo p.note a:hover {
   text-decoration: none;
 }
 

--- a/server/node/config.js
+++ b/server/node/config.js
@@ -7,6 +7,7 @@
 'use strict';
 
 // Load environment variables from the `.env` file.
+const stripe = require('stripe');
 require('dotenv').config();
 
 module.exports = {
@@ -32,7 +33,7 @@ module.exports = {
     'sofort', // eur (SOFORT must always use Euros)
     'wechat', // aud, cad, eur, gbp, hkd, jpy, sgd, or usd.
   ],
-
+  enableTracing: process.env.ENABLE_TRACING,
   // Configuration for Stripe.
   // API Keys: https://dashboard.stripe.com/account/apikeys
   // Webhooks: https://dashboard.stripe.com/account/webhooks
@@ -50,6 +51,7 @@ module.exports = {
     // Setting the webhook secret is good practice in order to verify signatures.
     // After creating a webhook, click to reveal details and find your signing secret.
     webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+    client: stripe(process.env.STRIPE_SECRET_KEY)
   },
 
   // Shipping options for the Payment Request API.

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -15,7 +15,7 @@ const setup = require('./setup');
 const {products} = require('./inventory');
 const express = require('express');
 const router = express.Router();
-const stripe = require('stripe')(config.stripe.secretKey);
+const stripe = config.stripe.client;
 stripe.setApiVersion(config.stripe.apiVersion);
 
 // Render the main app HTML.
@@ -176,6 +176,7 @@ router.post('/webhook', async (req, res) => {
 router.get('/config', (req, res) => {
   res.json({
     stripePublishableKey: config.stripe.publishableKey,
+    enableTracing: config.enableTracing,
     stripeCountry: config.stripe.country,
     country: config.country,
     currency: config.currency,

--- a/server/node/server.js
+++ b/server/node/server.js
@@ -33,6 +33,11 @@ app.use(express.static(path.join(__dirname, '../../public')));
 app.engine('html', require('ejs').renderFile);
 app.set('view engine', 'html');
 
+if (config.enableTracing) {
+  const tracer = require('./tracer');
+  tracer.traceApp({application: app, webhookPath: '/webhook'});
+}
+
 // Define routes.
 app.use('/', require('./routes'));
 


### PR DESCRIPTION
Here's a first stab at adding tracing to the payments demo.

## Motivation
Interactively trace payment flows for alternative payment methods and cards end-to-end. With these changes we can get frontend, backend and webhooks in one logical ordered swimlane view.

## Design

The idea is to keep as much of the tracing instrumentation and logic out of the main application so it isn't distracting.

This takes an optional backend dependency on `@stripe/aquarium` so if you don't have it it acts normally. You also need to have the environment variable `ENABLE_TRACING` set to trigger the tracing.

On the frontend, I've added a simple url configuration (`demoConfig`) to `store.js` we can use to store a tracing id and in the future possibly some other demo configurations. The frontend also pulls the tracing library from a cloud storage bucket.

@thorsten-stripe @mikeshaw-stripe 👀
