### PR TITLE
Python server: bump jinja2 and fix test

### DIFF
--- a/server/python/requirements.txt
+++ b/server/python/requirements.txt
@@ -8,7 +8,7 @@ gunicorn==19.7.1
 idna==2.6
 idna-ssl==1.1.0
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 livereload==2.5.1
 MarkupSafe==1.0
 more-itertools==4.1.0

--- a/server/python/tests/tests.py
+++ b/server/python/tests/tests.py
@@ -32,7 +32,7 @@ class AppTestCase(TestCase):
     def test_config(self):
         response = self.app.get('/config')
         self.assertListEqual(list(json.loads(response.data).keys()),
-                             ['country', 'currency', 'paymentMethods', 'stripeCountry', 'stripePublishableKey'])
+                             ['country', 'currency', 'paymentMethods', 'shippingOptions', 'stripeCountry', 'stripePublishableKey'])
         self.assertEqual(response.status_code, 200)
 
     def test_create_payment_intent(self):


### PR DESCRIPTION
Update `server/python/requirements.txt` for Jinja2 from 2.10 to 2.10.1.

Also, #48 added `shippingOptions` to the object returned by `/config`; this PR updates the Python tests accordingly.

r? @adreyfus-stripe || @thorsten-stripe 