### PR TITLE
Decouple product setup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "node": "8.x"
   },
   "scripts": {
-    "start": "node server/node/server.js"
+    "start": "node server/node/server.js",
+    "setup-products": "node server/node/setup.js",
+    "postinstall": "npm run setup-products"
   },
   "dependencies": {
     "body-parser": "^1.17.1",

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -174,9 +174,7 @@ class Store {
       let lineItem = document.createElement('div');
       lineItem.classList.add('line-item');
       lineItem.innerHTML = `
-        <img class="image" src="/images/products/${
-          product.metadata.img_scr
-        }.png">
+        <img class="image" src="/images/products/${product.id}.png">
         <div class="label">
           <p class="product">${product.name}</p>
           <p class="sku">${Object.values(sku.attributes).join(' ')}</p>

--- a/public/javascripts/store.js
+++ b/public/javascripts/store.js
@@ -71,6 +71,11 @@ class Store {
       this.productsFetchPromise = new Promise(async resolve => {
         const productsResponse = await fetch('/products');
         const products = (await productsResponse.json()).data;
+        if (!products.length) {
+          throw new Error(
+            'No products on Stripe account! Make sure the setup script has run properly.'
+          );
+        }
         // Check if we have SKUs on the product, otherwise load them separately.
         for (const product of products) {
           this.products[product.id] = product;
@@ -169,7 +174,9 @@ class Store {
       let lineItem = document.createElement('div');
       lineItem.classList.add('line-item');
       lineItem.innerHTML = `
-        <img class="image" src="/images/products/${product.id}.png">
+        <img class="image" src="/images/products/${
+          product.metadata.img_scr
+        }.png">
         <div class="label">
           <p class="product">${product.name}</p>
           <p class="sku">${Object.values(sku.attributes).join(' ')}</p>

--- a/server/node/inventory.js
+++ b/server/node/inventory.js
@@ -25,18 +25,6 @@ const retrieveProduct = async productId => {
   return await stripe.products.retrieve(productId);
 };
 
-// Validate that products exist.
-const productsExist = productList => {
-  const validProducts = ['increment', 'shirt', 'pins'];
-  return productList.data.reduce((accumulator, currentValue) => {
-    return (
-      accumulator &&
-      productList.data.length === 3 &&
-      validProducts.includes(currentValue.id)
-    );
-  }, !!productList.data.length);
-};
-
 // Get shipping cost from config based on selected shipping option.
 const getShippingCost = shippingOption => {
   return config.shippingOptions.filter(
@@ -47,6 +35,5 @@ const getShippingCost = shippingOption => {
 exports.products = {
   list: listProducts,
   retrieve: retrieveProduct,
-  exist: productsExist,
   getShippingCost,
 };

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const config = require('./config');
-const setup = require('./setup');
 const {products} = require('./inventory');
 const express = require('express');
 const router = express.Router();
@@ -192,15 +191,7 @@ router.get('/config', (req, res) => {
 
 // Retrieve all products.
 router.get('/products', async (req, res) => {
-  const productList = await products.list();
-  // Check if products exist on Stripe Account.
-  if (products.exist(productList)) {
-    res.json(productList);
-  } else {
-    // We need to set up the products.
-    await setup.run();
-    res.json(await products.list());
-  }
+  res.json(await products.list());
 });
 
 // Retrieve a product by ID.

--- a/server/node/setup.js
+++ b/server/node/setup.js
@@ -13,76 +13,56 @@ const config = require('./config');
 const stripe = require('stripe')(config.stripe.secretKey);
 stripe.setApiVersion(config.stripe.apiVersion);
 
-module.exports = {
-  running: false,
-  run: async () => {
-    if (this.running) {
-      console.log('⚠️  Setup already in progress.');
-    } else {
-      this.running = true;
-      this.promise = new Promise(async resolve => {
-        // Create a few products and SKUs assuming they don't already exist.
-        try {
-          // Increment Magazine.
-          const increment = await stripe.products.create({
-            id: 'increment',
-            type: 'good',
-            name: 'Increment Magazine',
-            attributes: ['issue'],
-          });
-          await stripe.skus.create({
-            id: 'increment-03',
-            product: 'increment',
-            attributes: {issue: 'Issue #3 “Development”'},
-            price: 399,
-            currency: config.currency,
-            inventory: {type: 'infinite'},
-          });
-
-          // Stripe Shirt.
-          const shirt = await stripe.products.create({
-            id: 'shirt',
-            type: 'good',
-            name: 'Stripe Shirt',
-            attributes: ['size', 'gender'],
-          });
-          await stripe.skus.create({
-            id: 'shirt-small-woman',
-            product: 'shirt',
-            attributes: {size: 'Small Standard', gender: 'Woman'},
-            price: 999,
-            currency: config.currency,
-            inventory: {type: 'infinite'},
-          });
-
-          // Stripe Pins.
-          const pins = await stripe.products.create({
-            id: 'pins',
-            type: 'good',
-            name: 'Stripe Pins',
-            attributes: ['set'],
-          });
-          await stripe.skus.create({
-            id: 'pins-collector',
-            product: 'pins',
-            attributes: {set: 'Collector Set'},
-            price: 799,
-            currency: config.currency,
-            inventory: {type: 'finite', quantity: 500},
-          });
-          console.log('Setup complete.');
-          resolve();
-          this.running = false;
-        } catch (err) {
-          if (err.message === 'Product already exists.') {
-            console.log('⚠️  Products have already been registered.');
-            console.log('Delete them from your Dashboard to run this setup.');
-          } else {
-            console.log('⚠️  An error occurred.', err);
-          }
-        }
-      });
-    }
-    return this.promise;
+// Replace this list with information about your store's products.
+const products = [
+  {
+    name: 'Increment Magazine',
+    price: 399,
+    attributes: {issue: 'Issue #3 “Development”'},
+    metadata: {img_scr: 'increment'},
   },
+  {
+    name: 'Stripe Shirt',
+    price: 999,
+    attributes: {size: 'Small Standard', gender: 'Woman'},
+    metadata: {img_scr: 'shirt'},
+  },
+  {
+    name: 'Stripe Pins',
+    price: 799,
+    attributes: {set: 'Collector Set'},
+    metadata: {img_scr: 'pins'},
+  },
+];
+
+// Creates a collection of Stripe Products and SKUs to use in your storefront
+const createStoreProducts = async () => {
+  const stripeProducts = await Promise.all(
+    products.map(async product => {
+      const stripeProduct = await stripe.products.create({
+        name: product.name,
+        type: 'good',
+        attributes: Object.keys(product.attributes),
+        metadata: product.metadata,
+      });
+
+      const stripeSku = await stripe.skus.create({
+        product: stripeProduct.id,
+        price: product.price,
+        currency: config.currency,
+        attributes: product.attributes,
+        inventory: {type: 'infinite'},
+      });
+
+      return {stripeProduct, stripeSku};
+    })
+  );
+
+  console.log(
+    `🛍️  Successfully created ${
+      stripeProducts.length
+    } products on your Stripe account.`
+  );
 };
+
+createStoreProducts();

--- a/server/node/setup.js
+++ b/server/node/setup.js
@@ -16,53 +16,59 @@ stripe.setApiVersion(config.stripe.apiVersion);
 // Replace this list with information about your store's products.
 const products = [
   {
+    id: 'increment',
     name: 'Increment Magazine',
     price: 399,
     attributes: {issue: 'Issue #3 “Development”'},
-    metadata: {img_scr: 'increment'},
   },
   {
+    id: 'shirt',
     name: 'Stripe Shirt',
     price: 999,
     attributes: {size: 'Small Standard', gender: 'Woman'},
-    metadata: {img_scr: 'shirt'},
   },
   {
+    id: 'pins',
     name: 'Stripe Pins',
     price: 799,
     attributes: {set: 'Collector Set'},
-    metadata: {img_scr: 'pins'},
   },
 ];
 
 // Creates a collection of Stripe Products and SKUs to use in your storefront
 const createStoreProducts = async () => {
-  const stripeProducts = await Promise.all(
-    products.map(async product => {
-      const stripeProduct = await stripe.products.create({
-        name: product.name,
-        type: 'good',
-        attributes: Object.keys(product.attributes),
-        metadata: product.metadata,
-      });
+  try {
+    const stripeProducts = await Promise.all(
+      products.map(async product => {
+        const stripeProduct = await stripe.products.create({
+          id: product.id,
+          name: product.name,
+          type: 'good',
+          attributes: Object.keys(product.attributes),
+          metadata: product.metadata,
+        });
 
-      const stripeSku = await stripe.skus.create({
-        product: stripeProduct.id,
-        price: product.price,
-        currency: config.currency,
-        attributes: product.attributes,
-        inventory: {type: 'infinite'},
-      });
+        const stripeSku = await stripe.skus.create({
+          product: stripeProduct.id,
+          price: product.price,
+          currency: config.currency,
+          attributes: product.attributes,
+          inventory: {type: 'infinite'},
+        });
 
-      return {stripeProduct, stripeSku};
-    })
-  );
+        return {stripeProduct, stripeSku};
+      })
+    );
 
-  console.log(
-    `🛍️  Successfully created ${
-      stripeProducts.length
-    } products on your Stripe account.`
-  );
+    console.log(
+      `🛍️  Successfully created ${
+        stripeProducts.length
+      } products on your Stripe account.`
+    );
+  } catch (error) {
+    console.log(`⚠️  Error: ${error.message}`);
+    return;
+  }
 };
 
 createStoreProducts();


### PR DESCRIPTION
closes #68 

* Make server/node/setup.js standalone script.
* Remove product exist checking which relies on hardcoded product names.
* Run product setup script on `postinstall` hook.