### PR TITLE
Upgrade runtime to nodejs10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ All servers have the same endpoints to handle requests from the frontend and int
 
 You’ll need the following:
 
-- [Node.js](http://nodejs.org) >= 8.x.
+- [Node.js](http://nodejs.org) >= 10.x.
 - Modern browser that supports ES6 (Chrome to see the Payment Request, and Safari to see Apple Pay).
 - Stripe account to accept payments ([sign up](https://dashboard.stripe.com/register) for free).
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,6 +1,6 @@
 # Configuration for Node in App Engine standard on Google Cloud Platform.
 
-runtime: nodejs8
+runtime: nodejs10
 instance_class: F1
 
 handlers:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/stripe/stripe-payments-demo.git"
   },
   "engines": {
-    "node": "8.x"
+    "node": "10.x"
   },
   "scripts": {
     "start": "node server/node/server.js",

--- a/server/node/README.md
+++ b/server/node/README.md
@@ -6,7 +6,7 @@ This directory contains the main Node implementation of the payments server.
 
 You’ll need the following:
 
-- [Node.js](http://nodejs.org) >= 8.x.
+- [Node.js](http://nodejs.org) >= 10.x.
 - Modern browser that supports ES6 (Chrome to see the Payment Request, and Safari to see Apple Pay).
 - Stripe account to accept payments ([sign up](https://dashboard.stripe.com/register) for free).
 


### PR DESCRIPTION
Motivation: Google AppEngine is deprecating nodjs8 runtime.