### PR TITLE
Increase ngrok version to 3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "stripe": "^6.28.0"
   },
   "devDependencies": {
-    "ngrok": "^3.1.1"
+    "ngrok": "^3.2.3"
   }
 }


### PR DESCRIPTION
Increase ngrok version to 3.2.3 in order to prevent timeout. See here: https://github.com/stripe/stripe-payments-demo/issues/82