### PR TITLE
Add Flask route to serve .well-known files

### DIFF
--- a/server/python/README.md
+++ b/server/python/README.md
@@ -53,6 +53,7 @@ pip install -r requirements.txt
 Export our Flask app and run!
 
 ```
+export FLASK_APP=./app.py
 flask run
 ```
 

--- a/server/python/app.py
+++ b/server/python/app.py
@@ -46,6 +46,11 @@ def serve_image(path):
     return send_from_directory(f'{static_dir}/images', path)
 
 
+@app.route('/.well-known/<path:path>', methods=["GET"])
+def serve_well_known(path):
+    return send_from_directory(f'{static_dir}/.well-known', path)
+
+
 # Serve config set up in .env
 @app.route('/config')
 def get_config():


### PR DESCRIPTION
This PR adds a Flask route that allows .well-known files to be served.  Previously the missing route prevented the addition of web domains when configuring Apple Pay in the Stripe dashboard.

The PR also adds an explicit hint to readers to export FLASK_APP before running the app.