### PR TITLE
Adding Przelewy24 to Stripe Payments Demo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ STRIPE_ACCOUNT_COUNTRY=US
 # Make sure to check the docs: https://stripe.com/docs/sources
 # Only used for servers that don't have a separate config/settings file. 
 # For Node.js see the server/node/config.js file!
-PAYMENT_METHODS="alipay, bancontact, card, eps, ideal, giropay, multibanco, sofort, wechat"
+PAYMENT_METHODS="alipay, bancontact, card, eps, ideal, giropay, multibanco, p24, sofort, wechat"
 
 # Optional ngrok configuration for development (if you have a paid ngrok account).
 NGROK_SUBDOMAIN=

--- a/public/index.html
+++ b/public/index.html
@@ -77,6 +77,7 @@
                   <option value="NL">Netherlands</option>
                   <option value="NZ">New Zealand</option>
                   <option value="NO">Norway</option>
+                  <option value="PL">Poland</option>
                   <option value="PT">Portugal</option>
                   <option value="SG">Singapore</option>
                   <option value="ES">Spain</option>
@@ -125,6 +126,10 @@
               <li>
                 <input type="radio" name="payment" id="payment-multibanco" value="multibanco">
                 <label for="payment-multibanco">Multibanco</label>
+              </li>
+              <li>
+                <input type="radio" name="payment" id="payment-p24" value="p24">
+                <label for="payment-p24">Przelewy24</label>
               </li>
               <li>
                 <input type="radio" name="payment" id="payment-sepa_debit" value="sepa_debit">

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -414,9 +414,9 @@
         'We’ll send your receipt and ship your items as soon as your payment is confirmed.';
       mainElement.classList.add('success');
     } else if (paymentIntent.status === 'requires_payment_method') {
-      // Failure. Requires new PaymentMethod.
+      // Failure. Requires new PaymentMethod, show last payment error message.
       mainElement.classList.remove('processing');
-      confirmationElement.querySelector('.error-message').innerText = 'Payment failed.';
+      confirmationElement.querySelector('.error-message').innerText = paymentIntent.last_payment_error || 'Payment failed';
       mainElement.classList.add('error');
     } else {
       // Payment has failed.

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -314,6 +314,21 @@
         }
       );
       handlePayment(response);
+    } else if (payment === 'p24') {
+      // Confirm the PaymentIntent with confirmP24Payment
+      const response = await stripe.confirmP24Payment(
+        paymentIntent.client_secret,
+        {
+          payment_method: {
+            billing_details: {
+              name,
+              email
+            }
+          },
+          return_url: window.location.href,
+        }
+      );
+      handlePayment(response);
     } else {
       // Prepare all the Stripe source common data.
       const sourceData = {
@@ -642,6 +657,12 @@
       flow: 'receiver',
       countries: ['PT'],
       currencies: ['eur'],
+    },
+    p24: {
+      name: 'Przelewy24',
+      flow: 'redirect',
+      countries: ['PL'],
+      currencies: ['eur', 'pln'],
     },
     sepa_debit: {
       name: 'SEPA Direct Debit',

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -413,6 +413,11 @@
       confirmationElement.querySelector('.note').innerText =
         'We’ll send your receipt and ship your items as soon as your payment is confirmed.';
       mainElement.classList.add('success');
+    } else if (paymentIntent.status === 'requires_payment_method') {
+      // Failure. Requires new PaymentMethod.
+      mainElement.classList.remove('processing');
+      confirmationElement.querySelector('.error-message').innerText = 'Payment failed.';
+      mainElement.classList.add('error');
     } else {
       // Payment has failed.
       mainElement.classList.remove('success');
@@ -540,7 +545,7 @@
     start = null
   ) => {
     start = start ? start : Date.now();
-    const endStates = ['succeeded', 'processing', 'canceled'];
+    const endStates = ['succeeded', 'processing', 'canceled', 'requires_payment_method'];
     // Retrieve the PaymentIntent status from our server.
     const rawResponse = await fetch(`payment_intents/${paymentIntent}/status`);
     const response = await rawResponse.json();

--- a/server/java/README.md
+++ b/server/java/README.md
@@ -31,7 +31,7 @@ export STRIPE_PUBLISHABLE_KEY=
 export STRIPE_SECRET_KEY=
 export STRIPE_WEBHOOK_SECRET=
 export STRIPE_ACCOUNT_COUNTRY=
-export PAYMENT_METHODS="alipay, bancontact, card, eps, ideal, giropay, multibanco, sofort, wechat"
+export PAYMENT_METHODS="alipay, bancontact, card, eps, ideal, giropay, multibanco, p24, sofort, wechat"
 export NGROK_SUBDOMAIN=
 export NGROK_AUTHTOKEN=
 ```

--- a/server/node/config.js
+++ b/server/node/config.js
@@ -29,6 +29,7 @@ module.exports = {
     'giropay', // eur (Giropay must always use Euros)
     'multibanco', // eur (Multibanco must always use Euros)
     // 'sepa_debit', // Restricted. See docs for activation details: https://stripe.com/docs/sources/sepa-debit
+    'p24', // eur, pln
     'sofort', // eur (SOFORT must always use Euros)
     'wechat', // aud, cad, eur, gbp, hkd, jpy, sgd, or usd.
   ],

--- a/server/node/routes.js
+++ b/server/node/routes.js
@@ -195,7 +195,13 @@ router.get('/products/:id', async (req, res) => {
 // Retrieve the PaymentIntent status.
 router.get('/payment_intents/:id/status', async (req, res) => {
   const paymentIntent = await stripe.paymentIntents.retrieve(req.params.id);
-  res.json({paymentIntent: {status: paymentIntent.status}});
+  const payload = {status: paymentIntent.status};
+
+  if (paymentIntent.last_payment_error) {
+    payload.last_payment_error = paymentIntent.last_payment_error.message;
+  }
+
+  res.json({paymentIntent: payload});
 });
 
 module.exports = router;

--- a/server/php/settings.php
+++ b/server/php/settings.php
@@ -39,6 +39,7 @@ return [
             'ideal', // eur (iDEAL must always use Euros)
             'giropay', // eur (Giropay must always use Euros)
             'multibanco', // eur (Multibanco must always use Euros)
+            'p24', // eur, pln
             // 'sepa_debit', // Restricted. See docs for activation details: https://stripe.com/docs/sources/sepa-debit
             'sofort', // eur (SOFORT must always use Euros)
             'wechat' // aud, cad, eur, gbp, hkd, jpy, sgd, or usd.


### PR DESCRIPTION
# Context
Per https://github.com/stripe/stripe-payments-demo/issues/142, adding Przelewy24 as a payment method.

cc. @thorsten-stripe @rgultiano-stripe 

# Todo
- [ ] Add `last_payment_error` to other back-ends, if we agree it's a good idea

# Changes
* Added P24 availability to `.env.example`, Node and PHP configs
* Added P24 handler and config to `payments.js`
  * Added error handling for `requires_payment_method` status, forward last error message
* Added 🇵🇱 to country selection, and P24 payment method to `index.html`


# Screenshots
*P24 payment method selection*
<img width="1280" alt="Screenshot 2020-07-20 at 13 58 27" src="https://user-images.githubusercontent.com/50152098/87940181-1a633780-ca91-11ea-9fd5-f181079ce36d.png">

*Authentication failure of P24 payment*
<img width="1011" alt="Screenshot 2020-07-20 at 14 26 57" src="https://user-images.githubusercontent.com/50152098/87942857-1e915400-ca95-11ea-9514-ba3c7dc4294b.png">