### PR TITLE
Publish "last payment error" from each backend server

### DIFF
--- a/server/go/app.go
+++ b/server/go/app.go
@@ -138,17 +138,31 @@ func buildEcho(publicDirectory string) *echo.Echo {
 		})
 	})
 
+	type PaymentIntentsStatusData struct {
+		Status           string `json:"status"`
+		LastPaymentError string `json:"last_payment_error,omitempty"`
+	}
+
+	type PaymentIntentsStatus struct {
+		PaymentIntent PaymentIntentsStatusData `json:"paymentIntent"`
+	}
+
 	e.GET("/payment_intents/:id/status", func(c echo.Context) error {
 		pi, err := payments.RetrieveIntent(c.Param("id"))
 		if err != nil {
 			return err
 		}
 
-		return c.JSON(http.StatusOK, map[string]map[string]string{
-			"paymentIntent": {
-				"status": string(pi.Status),
+		p := PaymentIntentsStatus{
+			PaymentIntent: PaymentIntentsStatusData{
+				Status: string(pi.Status),
 			},
-		})
+		}
+		if pi.LastPaymentError != nil {
+			p.PaymentIntent.LastPaymentError = pi.LastPaymentError.Message
+		}
+
+		return c.JSON(http.StatusOK, p)
 	})
 
 	e.POST("/webhook", func(c echo.Context) error {

--- a/server/go/go.mod
+++ b/server/go/go.mod
@@ -1,10 +1,12 @@
 module github.com/stripe/stripe-payments-demo
 
+go 1.14
+
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
-	github.com/joho/godotenv v1.3.0 // indirect
-	github.com/labstack/echo v3.3.10+incompatible // indirect
-	github.com/labstack/gommon v0.2.8 // indirect
+	github.com/joho/godotenv v1.3.0
+	github.com/labstack/echo v3.3.10+incompatible
+	github.com/labstack/gommon v0.2.8
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/stripe/stripe-go v60.6.0+incompatible

--- a/server/java/src/main/java/app/payment/PaymentController.java
+++ b/server/java/src/main/java/app/payment/PaymentController.java
@@ -57,6 +57,11 @@ public class PaymentController {
         Map<String, Object> status = new HashMap<>();
         status.put("status", paymentIntent.getStatus());
 
+        
+        if (paymentIntent.getLastPaymentError() != null) {
+            status.put("last_payment_error", paymentIntent.getLastPaymentError().getMessage());
+        }
+        
         Map<String, Object> wrapper = new HashMap<String, Object>();
         wrapper.put("paymentIntent", status);
 

--- a/server/php/index.php
+++ b/server/php/index.php
@@ -118,8 +118,14 @@ $app->post('/payment_intents/{id}/shipping_change', function (Request $request, 
 // Fetch the payment intent status
 // Used for redirect sources when coming back to the return URL
 $app->get('/payment_intents/{id}/status', function (Request $request, Response $response, array $args) {
-    $paymentIntent = \Stripe\PaymentIntent::retrieve($args['id']);
-    return $response->withJson([ 'paymentIntent' => [ 'status' => $paymentIntent->status ] ]);
+  $paymentIntent = \Stripe\PaymentIntent::retrieve($args['id']);
+  $data = [ 'paymentIntent' => [ 'status' => $paymentIntent->status ] ];
+
+  if ($paymentIntent->last_payment_error) {
+    $data['paymentIntent']['last_payment_error'] = $paymentIntent->last_payment_error->message;
+  }
+
+  return $response->withJson($data);
 });
 
 // Events receiver for payment intents and sources

--- a/server/python/app.py
+++ b/server/python/app.py
@@ -198,7 +198,16 @@ def webhook_received():
 @app.route('/payment_intents/<string:id>/status', methods=['GET'])
 def retrieve_payment_intent_status(id):
     payment_intent = stripe.PaymentIntent.retrieve(id)
-    return jsonify({'paymentIntent': {'status': payment_intent["status"]}})
+    data = {
+        'paymentIntent': {
+            'status': payment_intent["status"]
+        }
+    }
+
+    if payment_intent['last_payment_error']:
+        data['paymentIntent']['last_payment_error'] = payment_intent['last_payment_error']['message']
+
+    return jsonify(data)
 
 
 if __name__ == '__main__':

--- a/server/ruby/app.rb
+++ b/server/ruby/app.rb
@@ -224,10 +224,16 @@ get '/payment_intents/:id/status' do
     params['id']
   )
 
-  content_type 'application/json'
-  {
+  data = {
     paymentIntent: {
       status: payment_intent['status']
     }
-  }.to_json
+  }
+
+  data[:paymentIntent] = data[:paymentIntent].merge(
+    last_payment_error: payment_intent.last_payment_error.message
+  ) if payment_intent.last_payment_error
+
+  content_type 'application/json'
+  data.to_json
 end


### PR DESCRIPTION
In #143, we added a concept of the server returning the `PaymentIntent`'s `last_payment_error` to the browser. We implemented this in Node, but not the other languages.

This PR adds the message to the Go, Ruby, Python, PHP and Java servers, giving a UX improvement when running those examples.