### PR TITLE
Fix polling of `PaymentIntent` status

### DIFF
--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -602,10 +602,10 @@
     // Retrieve the PaymentIntent status from our server.
     const rawResponse = await fetch(`payment_intents/${paymentIntent}/status`);
     const response = await rawResponse.json();
-    const isTerminal = paymentIntentTerminalState(response.paymentIntent);
+    const isTerminalState = paymentIntentTerminalState(response.paymentIntent);
 
     if (
-      !isTerminal &&
+      !isTerminalState &&
       Date.now() < start + timeout
     ) {
       // Not done yet. Let's wait and check again.
@@ -619,7 +619,7 @@
       );
     } else {
       handlePayment(response);
-      if (!isTerminal) {
+      if (!isTerminalState) {
         // Status has not changed yet. Let's time out.
         console.warn(new Error('Polling timed out.'));
       }

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -574,6 +574,17 @@
   };
 
   /**
+   * Check if the PaymentIntent is in a "terminal" status
+   * and therefore if we should show an error in the UI
+   */
+  const paymentIntentTerminal = ({status, last_payment_error}) => {
+    const endStates = ['succeeded', 'processing', 'canceled'],
+          hasError = typeof last_payment_error !== "undefined";
+
+    return endStates.includes(status) || status === 'requires_payment_method' && hasError;
+  };
+
+  /**
    * Monitor the status of a source after a redirect flow.
    *
    * This means there is a `source` parameter in the URL, and an active PaymentIntent.
@@ -588,12 +599,13 @@
     start = null
   ) => {
     start = start ? start : Date.now();
-    const endStates = ['succeeded', 'processing', 'canceled', 'requires_payment_method'];
     // Retrieve the PaymentIntent status from our server.
     const rawResponse = await fetch(`payment_intents/${paymentIntent}/status`);
     const response = await rawResponse.json();
+    const isTerminal = paymentIntentTerminal(response.paymentIntent);
+
     if (
-      !endStates.includes(response.paymentIntent.status) &&
+      !isTerminal &&
       Date.now() < start + timeout
     ) {
       // Not done yet. Let's wait and check again.
@@ -607,7 +619,7 @@
       );
     } else {
       handlePayment(response);
-      if (!endStates.includes(response.paymentIntent.status)) {
+      if (!isTerminal) {
         // Status has not changed yet. Let's time out.
         console.warn(new Error('Polling timed out.'));
       }

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -578,8 +578,8 @@
    * and therefore if we should show an error in the UI
    */
   const paymentIntentTerminal = ({status, last_payment_error}) => {
-    const endStates = ['succeeded', 'processing', 'canceled'],
-          hasError = typeof last_payment_error !== "undefined";
+    const endStates = ['succeeded', 'processing', 'canceled'];
+    const hasError = typeof last_payment_error !== "undefined";
 
     return endStates.includes(status) || (status === 'requires_payment_method' && hasError);
   };

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -581,7 +581,7 @@
     const endStates = ['succeeded', 'processing', 'canceled'],
           hasError = typeof last_payment_error !== "undefined";
 
-    return endStates.includes(status) || status === 'requires_payment_method' && hasError;
+    return endStates.includes(status) || (status === 'requires_payment_method' && hasError);
   };
 
   /**

--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -577,7 +577,7 @@
    * Check if the PaymentIntent is in a "terminal" status
    * and therefore if we should show an error in the UI
    */
-  const paymentIntentTerminal = ({status, last_payment_error}) => {
+  const paymentIntentTerminalState = ({status, last_payment_error}) => {
     const endStates = ['succeeded', 'processing', 'canceled'];
     const hasError = typeof last_payment_error !== "undefined";
 
@@ -602,7 +602,7 @@
     // Retrieve the PaymentIntent status from our server.
     const rawResponse = await fetch(`payment_intents/${paymentIntent}/status`);
     const response = await rawResponse.json();
-    const isTerminal = paymentIntentTerminal(response.paymentIntent);
+    const isTerminal = paymentIntentTerminalState(response.paymentIntent);
 
     if (
       !isTerminal &&


### PR DESCRIPTION
## Background
In #143, I broke `PaymentIntent` `status` polling for certain payment methods, like WeChat. A fellow developer filed #148 to report this.

## Changes
More explicitly check if a `PaymentIntent` is in a terminal state by checking for `last_payment_error` in the back-end response.