### PR TITLE
Move Alipay to PaymentIntents

### DIFF
--- a/public/javascripts/payments.js
+++ b/public/javascripts/payments.js
@@ -383,6 +383,19 @@
         }
       );
       handlePayment(response);
+    } else if (payment === 'alipay') {
+      const response = await stripe.confirmAlipayPayment(
+        paymentIntent.client_secret,
+        {
+          payment_method: {
+            billing_details: {
+              name,
+            }
+          },
+          return_url: window.location.href,
+        }
+      );
+      handlePayment(response);
     } else {
       // Prepare all the Stripe source common data.
       const sourceData = {


### PR DESCRIPTION
## Context
Per the [documentation](https://stripe.com/docs/payments/alipay/accept-a-payment), Alipay is now generally available on the `PaymentIntents` API, so this simply adds a handler to call `confirmAlipayPayment` via Stripe.js, rather than creating a `Source`.

## Changes
- Add Alipay handler to `payments.js`